### PR TITLE
Lowercase navigation links on larger screens

### DIFF
--- a/modules/_header.sass
+++ b/modules/_header.sass
@@ -55,6 +55,7 @@ $toggle-width: 900px
         > li > a
           padding: 5px 15px
           white-space: nowrap
+          text-transform: lowercase
 
     a.active
       background: $border


### PR DESCRIPTION
This way the CSS controls how the navigation items look rather than how
we have written the label in the HTML. The advantage of this that the
mobile view now uses the same capitalization for items, where previously
the "home", "docs" and "blog" links would be lowercase where the tour
links would all be capitalized.

## Screenshots

Left this PR, right current:

Mobile:
![image](https://user-images.githubusercontent.com/282402/54385778-bb6d0180-4697-11e9-8e81-f64780f3806a.png)

Desktop:
![image](https://user-images.githubusercontent.com/282402/54385811-cde73b00-4697-11e9-85da-3bd8916211f4.png)
