### PR TITLE
Fix tour item hover background in navigation

### DIFF
--- a/modules/_header.sass
+++ b/modules/_header.sass
@@ -184,6 +184,7 @@ $toggle-width: 900px
 
         a
           padding: 20px
+          height: 100%
 
         a:hover
           img


### PR DESCRIPTION
Not all list items in the navigation are of the same height. If any item
other than "workflow features" was active there would be a gap between
the a-element's background color and end of the navigation list item.

By making the a-element have a height of 100% we fill the entire
navigation list item, filling the gap.

## Screenshots

Before:
![Error Tracking for Ruby and Elixir  AppSignal 2019-04-02 11-17-20(1)](https://user-images.githubusercontent.com/282402/55391264-50e20f80-5539-11e9-8eb8-4473187be0a4.png)



After:
![Error Tracking for Ruby and Elixir  AppSignal 2019-04-02 11-17-24](https://user-images.githubusercontent.com/282402/55391231-3f006c80-5539-11e9-8e29-f50639727c40.png)
