### PR TITLE
Use major third typographic scale

### DIFF
--- a/tokens/font.json
+++ b/tokens/font.json
@@ -3,27 +3,42 @@
     "type": "size",
     "category": "font-size"
   },
-  "props": {
-    "FONT_SIZE_TINY": {
-      "value": "0.625rem"
+  "props": [
+    {
+      "name": "FONT_SIZE_TINY",
+      "value": "0.64rem"
     },
-    "FONT_SIZE_SMALL": {
-      "value": "0.875rem"
+    {
+      "name": "FONT_SIZE_SMALL",
+      "value": "0.8rem"
     },
-    "FONT_SIZE_NORMAL": {
+    {
+      "name": "FONT_SIZE_ROOT",
+      "value": "16px"
+    },
+    {
+      "name": "FONT_SIZE_NORMAL",
       "value": "1rem"
     },
-    "FONT_SIZE_MEDIUM": {
+    {
+      "name": "FONT_SIZE_MEDIUM",
       "value": "1.25rem"
     },
-    "FONT_SIZE_LARGE": {
+    {
+      "name": "FONT_SIZE_LARGE",
       "value": "1.5rem"
     },
-    "FONT_SIZE_X_LARGE": {
-      "value": "2.5rem"
+    {
+      "name": "FONT_SIZE_X_LARGE",
+      "value": "1.953rem"
     },
-    "FONT_SIZE_XX_LARGE": {
-      "value": "3.125rem"
+    {
+      "name": "FONT_SIZE_XX_LARGE",
+      "value": "2.441rem"
+    },
+    {
+      "name": "FONT_SIZE_XXX_LARGE",
+      "value": "3.052rem"
     }
-  }
+  ]
 }


### PR DESCRIPTION
File this on under "suggested change", it's purely a recommendation and you can choose not to merge this if you feel that it's unnecessary. :)

This PR modifies the font sizes of several font sizes so that they conform to a modular typographic scale. I looked over the designs and the most similar scale I could find to the one you have already designed is the *major third* (a ratio of 1.250). [This article](https://medium.com/codyhouse/create-your-design-system-part-1-typography-7c630d9092bd) does a good job of explaining why this is a good thing.

This pull request also:

- Adds `FONT_SIZE_ROOT`, the root font size that `rem` units scale from.
- Use an array of objects, which guarantees the order of items in the styleguide

From here, we can then work out our vertical rhythm from these sizes and the line height (based on your designs, I'd suggest we set this at 1.5):

https://zellwk.com/blog/why-vertical-rhythms/
https://zellwk.com/blog/responsive-vertical-rhythm/
