### PR TITLE
Add prototype type and spacing scale

### DIFF
--- a/src/components/navigation.css
+++ b/src/components/navigation.css
@@ -4,7 +4,7 @@
   list-style: none;
 
   &__item {
-    margin-right: 2rem;
+    margin-right: var(--spacing-medium);
   }
 
   &__link {

--- a/src/components/topbar.css
+++ b/src/components/topbar.css
@@ -3,7 +3,7 @@
   border-bottom: 1px solid var(--color-brand-grey);
 
   &__logo {
-    margin-right: 4rem;
+    margin-right: var(--spacing-large);
   }
 
   &__login {

--- a/src/elements/typography.css
+++ b/src/elements/typography.css
@@ -1,0 +1,22 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 1.25rem;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+blockquote,
+ol,
+p,
+ul {
+  margin: 0 0 var(--spacing-normal);
+  opacity: 0.8;
+}
+
+a {
+  color: var(--color-brand-darkest);
+}

--- a/src/generated/index.custom-properties.css
+++ b/src/generated/index.custom-properties.css
@@ -73,35 +73,38 @@
   --monospaced: Alma Mono;
 
   /* Grid gutter size */
-  --spacing-grid-gutter: 24px;
+  --spacing-grid-gutter: 1.5rem;
 
   /* Grid outside margin */
-  --spacing-grid-margin: 36px;
+  --spacing-grid-margin: 2.25rem;
 
   /* Grid column size */
-  --spacing-grid-column: 72px;
+  --spacing-grid-column: 45rem;
 
   /* For micro adjustments */
-  --spacing-x-small: 2px;
+  --spacing-xx-small: 0.444rem;
 
   /* For micro adjustments */
-  --spacing-small: 4px;
+  --spacing-x-small: 0.667rem;
 
   /* For paddings in labels / inline stuff */
-  --spacing-medium: 8px;
+  --spacing-small: 1rem;
 
   /* Regular padding for compact tables and such */
-  --spacing-normal: 16px;
+  --spacing-normal: 1.5rem;
+
+  /* For paddings in labels / inline stuff */
+  --spacing-medium: 2.25rem;
 
   /* Padding for the inside of boxes */
-  --spacing-large: 24px;
+  --spacing-large: 3.375rem;
 
   /* Padding between elements and for boxes with larger font-sizes */
-  --spacing-x-large: 36px;
+  --spacing-x-large: 5.0625rem;
 
   /* Larger padding for when bigger spacing is needed */
-  --spacing-xx-large: 48px;
+  --spacing-xx-large: 7.6rem;
 
   /* Huge padding we can use for seperation of vertical sections */
-  --spacing-xxx-large: 96px;
+  --spacing-xxx-large: 11.4rem;
 }

--- a/src/generic/typography.css
+++ b/src/generic/typography.css
@@ -1,7 +1,12 @@
 html,
 body {
+  color: var(--color-brand-darkest);
   font-family: var(--default), sans-serif;
 
   /* base font size, equal to --font-size-normal */
   font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: normal;
+  line-height: 1.5;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,7 @@
  *
  */
 
+@import "./elements/typography";
 @import "./elements/headings";
 
 /*

--- a/src/objects/grid.css
+++ b/src/objects/grid.css
@@ -1,6 +1,6 @@
 .o-grid {
   display: grid;
-  grid-column-gap: 1.5rem;
+  grid-column-gap: var(--spacing-grid-gutter);
   grid-row-gap: 1rem;
 
   @media (min-width: 75rem) {

--- a/src/objects/layout.css
+++ b/src/objects/layout.css
@@ -2,5 +2,5 @@
   max-width: 75rem;
   height: 100%;
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 var(--spacing-grid-margin);
 }

--- a/tokens/spacing.json
+++ b/tokens/spacing.json
@@ -6,57 +6,62 @@
   "props": [
     {
       "name": "SPACING_GRID_GUTTER",
-      "value": "24px",
+      "value": "1.5rem",
       "comment": "Grid gutter size"
     },
     {
       "name": "SPACING_GRID_MARGIN",
-      "value": "36px",
+      "value": "2.25rem",
       "comment": "Grid outside margin"
     },
     {
       "name": "SPACING_GRID_COLUMN",
-      "value": "72px",
+      "value": "45rem",
       "comment": "Grid column size"
     },
     {
+      "name": "SPACING_XX_SMALL",
+      "value": "0.444rem",
+      "comment": "For micro adjustments"
+    },
+    {
       "name": "SPACING_X_SMALL",
-      "value": "2px",
+      "value": "0.667rem",
       "comment": "For micro adjustments"
     },
     {
       "name": "SPACING_SMALL",
-      "value": "4px",
-      "comment": "For micro adjustments"
-    },
-    {
-      "name": "SPACING_MEDIUM",
-      "value": "8px",
+      "value": "1rem",
       "comment": "For paddings in labels / inline stuff"
     },
     {
       "name": "SPACING_NORMAL",
-      "value": "16px",
-      "comment": "Regular padding for compact tables and such"
+      "value": "1.5rem",
+      "comment": "Regular padding for compact tables and such."
+    },
+    {
+      "name": "SPACING_MEDIUM",
+      "value": "2.25rem",
+      "comment": "For paddings in labels / inline stuff"
     },
     {
       "name": "SPACING_LARGE",
-      "value": "24px",
+      "value": "3.375rem",
       "comment": "Padding for the inside of boxes"
     },
     {
       "name": "SPACING_X_LARGE",
-      "value": "36px",
+      "value": "5.0625rem",
       "comment": "Padding between elements and for boxes with larger font-sizes"
     },
     {
       "name": "SPACING_XX_LARGE",
-      "value": "48px",
+      "value": "7.6rem",
       "comment": "Larger padding for when bigger spacing is needed"
     },
     {
       "name": "SPACING_XXX_LARGE",
-      "value": "96px",
+      "value": "11.4rem",
       "comment": "Huge padding we can use for seperation of vertical sections"
     }
   ]


### PR DESCRIPTION
This pull request adds a prototype typographic scale and spacing scale.

<img width="1222" alt="Screenshot 2019-08-16 at 21 45 26" src="https://user-images.githubusercontent.com/16296989/63194025-35524e00-c06f-11e9-9be9-b5aae10ceb26.png">

## How were these values created?

- The width of the grid gutters is currently `1.5rem` (24px). 
- The base font size is `1rem` (16px).

We use *1.5* as our "magic number". The `line-height` of `body` is set to 1.5, and this value multiplied by the element's font size is `1.5rem`. The default `margin-bottom` on text is also `1.5rem`.

We spoke about the headings having a smaller margin and line height. We set the `margin-bottom` to `1.25rem`, and the `line-height` to 1.25. Using our major thirds scale, a heading with the font size of `3.052rem` (48.832px) will have a computed `line-height` of 61.04px.

For the vertical spacing scale, we set our "normal" spacing value to `1.5rem` (same as our gutter size and our text `line-height`). This is our "rhythm unit". Then, for every unit on the scale, we _multiply the previous number in the scale by 1.5_. For example, the next spacing unit up from `1.5rem` would be `2.25rem`.

TL;DR: the magic number is 1.5, unless you use a heading, in which case the number is 1.25.

This deviates a little from the values you defined [here](https://github.com/appsignal/design-language/pull/20#issuecomment-520821588), but using these values (to my eye) seemed to make the line height too squashed at smaller viewport sizes. Again, the values here are not important, you can substitute whatever "magic numbers" you choose.

## How to test

Ensure `design-language` is checked out to this branch.  Ensure `component-library` is checked out to `feature/topbar-component` to see these changes in the "Typography" story, and how the spacings look in the `TopBar`.

## Why not fluid type?

After experimenting with [fluid type](https://www.smashingmagazine.com/2016/05/fluid-typography/), I decided to not use it for this feature as, when I used the code examples in the link, the text didn't look right and vertical rhythm appeared to be extremely unpredictable. I do think, however, this may be potentially super useful for UI elements in the app, which are more independent of vertical rhythm.