### PR TITLE
Build tokens on every command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "theo": "^8.1.4"
   },
   "scripts": {
-    "build": "postcss src/index.css -o dist/design-language.css",
-    "build:watch": "postcss src/index.css -o dist/design-language.css -w",
+    "build": "yarn build:tokens && postcss src/index.css -o dist/design-language.css",
+    "build:watch": "yarn build:tokens && postcss src/index.css -o dist/design-language.css -w",
     "build:tokens": "theo tokens/index.json --format custom-properties.css --dest src/generated",
     "lint": "stylelint 'src/**/*.css'",
     "lint:fix": "stylelint 'src/**/*.css' --fix",


### PR DESCRIPTION
There is no real reason not to build tokens when you run `yarn build`.
Adding this to every command makes sure we don't forget to generate the
custom-properties file.

For me the trigger to add this was that I checked this repo out, and realised someone forgot to build the tokens (The file changed when I ran the command). Let's make this a thing people don't have to think about.