### PR TITLE
Remove .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 /generated/
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.associations": {
-    "*.css": "postcss"
-  }
-}


### PR DESCRIPTION
We generally don't have editor related code in our codebase. I added it
to the .gitignore so people can have this locally if they choose to do
so.