### PR TITLE
Add classes for Background and Text colors

### DIFF
--- a/src/components/button.css
+++ b/src/components/button.css
@@ -4,7 +4,7 @@
   border-radius: var(--border-radius);
   outline: none;
   background-color: var(--color-white);
-  color: var(--color-darkest);
+  color: var(--color-grey-darkest);
   font-weight: 500;
   line-height: calc(1em - 1px);
   text-align: center;
@@ -58,12 +58,12 @@
   &--secondary {
     border-color: var(--color-border-dark);
     background-color: var(--color-white);
-    color: var(--color-dark);
+    color: var(--color-grey-dark);
   }
 
   &--secondary:hover {
     background-color: var(--color-grey-light);
-    color: var(--color-darkest);
+    color: var(--color-grey-darkest);
   }
 
   &:not(.is-disabled) {

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -3,8 +3,8 @@
   border: 1px solid var(--color-border-dark);
   border-radius: var(--border-radius);
   outline: none;
-  background-color: var(--color-brand-white);
-  color: var(--color-brand-darkest);
+  background-color: var(--color-white);
+  color: var(--color-darkest);
   font-weight: 500;
   line-height: calc(1em - 1px);
   text-align: center;
@@ -33,39 +33,39 @@
   }
 
   &--primary {
-    border-color: var(--color-brand-green);
-    background-color: var(--color-brand-green);
-    color: var(--color-brand-white);
+    border-color: var(--color-green);
+    background-color: var(--color-green);
+    color: var(--color-white);
   }
 
   &--primary:hover {
-    border-color: var(--color-brand-green-dark);
-    background-color: var(--color-brand-green-dark);
+    border-color: var(--color-green-dark);
+    background-color: var(--color-green-dark);
   }
 
   &--subtle {
-    border-color: var(--color-brand-green-light);
-    background-color: var(--color-brand-green-light);
-    color: var(--color-brand-green);
+    border-color: var(--color-green-light);
+    background-color: var(--color-green-light);
+    color: var(--color-green);
   }
 
   &--subtle:hover {
-    border-color: var(--color-brand-green-medium);
-    background-color: var(--color-brand-green-medium);
-    color: var(--color-brand-green-dark);
+    border-color: var(--color-green-medium);
+    background-color: var(--color-green-medium);
+    color: var(--color-green-dark);
   }
 
   &--secondary {
     border-color: var(--color-border-dark);
-    background-color: var(--color-brand-white);
-    color: var(--color-brand-dark);
+    background-color: var(--color-white);
+    color: var(--color-dark);
   }
 
   &--secondary:hover {
-    background-color: var(--color-brand-grey-light);
-    color: var(--color-brand-darkest);
+    background-color: var(--color-grey-light);
+    color: var(--color-darkest);
   }
-  
+
   &:not(.is-disabled) {
     cursor: pointer;
   }

--- a/src/components/navigation.css
+++ b/src/components/navigation.css
@@ -9,11 +9,11 @@
 
   &__link {
     display: block;
-    color: var(--color-brand-dark);
+    color: var(--color-grey-dark);
     text-decoration: none;
   }
 
   &__link:hover {
-    color: var(--color-brand-darkest);
+    color: var(--color-grey-darkest);
   }
 }

--- a/src/components/topbar.css
+++ b/src/components/topbar.css
@@ -1,6 +1,6 @@
 .c-topbar {
   height: 7.5rem;
-  border-bottom: 1px solid var(--color-brand-grey);
+  border-bottom: 1px solid var(--color-grey-grey);
 
   &__logo {
     margin-right: var(--spacing-large);

--- a/src/elements/typography.css
+++ b/src/elements/typography.css
@@ -18,5 +18,5 @@ ul {
 }
 
 a {
-  color: var(--color-brand-darkest);
+  color: var(--color-grey-darkest);
 }

--- a/src/generated/index.custom-properties.css
+++ b/src/generated/index.custom-properties.css
@@ -7,59 +7,56 @@
   --color-border-dark: #c9cfdd;
   --color-border: #f5f6f9;
 
-  /* Brand color white */
-  --color-brand-white: #fff;
+  /* color white */
+  --color-white: #fff;
 
-  /* Brand color grey light */
-  --color-brand-grey-light: #f5f6f9;
+  /* color grey light */
+  --color-grey-light: #f5f6f9;
 
-  /* Brand color grey */
-  --color-brand-grey: #c9cfdd;
+  /* color grey */
+  --color-grey: #c9cfdd;
 
-  /* Brand color dark */
-  --color-brand-dark: #6b7b96;
+  /* color dark */
+  --color-grey-dark: #6b7b96;
 
-  /* Brand color darkest */
-  --color-brand-darkest: #011940;
+  /* color darkest */
+  --color-grey-darkest: #011940;
 
-  /* Brand color green light */
-  --color-brand-green-light: #cef1e4;
+  /* color green light */
+  --color-green-light: #cef1e4;
 
-  /* Brand color green medium */
-  --color-brand-green-medium: #9de3c8;
+  /* color green medium */
+  --color-green-medium: #9de3c8;
 
-  /* Brand color green */
-  --color-brand-green: #09ba76;
+  /* color green */
+  --color-green: #09ba76;
 
-  /* Brand color green_dark */
-  --color-brand-green-dark: #069961;
+  /* color green_dark */
+  --color-green-dark: #069961;
 
-  /* Theme color Green */
-  --color-theme-green: #09ba76;
+  /* color Pink */
+  --color-pink: #ff6a9c;
 
-  /* Theme color Pink */
-  --color-theme-pink: #ff6a9c;
+  /* color Red */
+  --color-red: #d20325;
 
-  /* Theme color Red */
-  --color-theme-red: #d20325;
+  /* color Orange */
+  --color-orange: #f35320;
 
-  /* Theme color Orange */
-  --color-theme-orange: #f35320;
+  /* color purple */
+  --color-purple: #7826a2;
 
-  /* Theme color purple */
-  --color-theme-purple: #7826a2;
+  /* color Blue */
+  --color-blue: #2166cd;
 
-  /* Theme color Blue */
-  --color-theme-blue: #2166cd;
+  /* color Cyan */
+  --color-cyan: #029b9b;
 
-  /* Theme color Cyan */
-  --color-theme-cyan: #029b9b;
+  /* color brown */
+  --color-brown: #8e523d;
 
-  /* Theme color brown */
-  --color-theme-brown: #8e523d;
-
-  /* Theme color Yellow */
-  --color-theme-yellow: #f8a221;
+  /* color Yellow */
+  --color-yellow: #f8a221;
   --font-size-tiny: 0.64rem;
   --font-size-small: 0.8rem;
   --font-size-root: 16px;
@@ -90,7 +87,7 @@
   /* For paddings in labels / inline stuff */
   --spacing-small: 1rem;
 
-  /* Regular padding for compact tables and such */
+  /* Regular padding for compact tables and such. */
   --spacing-normal: 1.5rem;
 
   /* For paddings in labels / inline stuff */

--- a/src/generic/typography.css
+++ b/src/generic/typography.css
@@ -1,6 +1,6 @@
 html,
 body {
-  color: var(--color-brand-darkest);
+  color: var(--color-grey-darkest);
   font-family: var(--default), sans-serif;
 
   /* base font size, equal to --font-size-normal */

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,7 @@
 @import "./utils/bg-color";
 @import "./utils/grid";
 @import "./utils/layout";
+@import "./utils/text-color";
 @import "./utils/visibility";
 
 /*

--- a/src/utils/bg-color.css
+++ b/src/utils/bg-color.css
@@ -1,5 +1,73 @@
 .u-bg {
+  &--white {
+    background: var(--color-white);
+  }
+
+  &--grey-light {
+    background: var(--color-grey-light);
+  }
+
+  &--grey {
+    background: var(--color-grey);
+  }
+
+  &--grey-dark {
+    background: var(--color-grey-dark);
+  }
+
+  &--grey-darkest {
+    background: var(--color-grey-darkest);
+  }
+
+  &--green-light {
+    background: var(--color-green-light);
+  }
+
+  &--green-medium {
+    background: var(--color-green-medium);
+  }
+
+  &--green {
+    background: var(--color-green);
+  }
+
+  &--green-dark {
+    background: var(--color-green-dark);
+  }
+
+  &--pink {
+    background: var(--color-pink);
+  }
+
+  &--red {
+    background: var(--color-red);
+  }
+
+  &--orange {
+    background: var(--color-orange);
+  }
+
+  &--purple {
+    background: var(--color-purple);
+  }
+
+  &--blue {
+    background: var(--color-blue);
+  }
+
+  &--cyan {
+    background: var(--color-cyan);
+  }
+
+  &--brown {
+    background: var(--color-brown);
+  }
+
+  &--yellow {
+    background: var(--color-yellow);
+  }
+
   &--primary {
-    background: var(--color-brand-green);
+    background: var(--color-green);
   }
 }

--- a/src/utils/text-color.css
+++ b/src/utils/text-color.css
@@ -1,0 +1,73 @@
+.u-text {
+  &--white {
+    color: var(--color-white);
+  }
+
+  &--grey-light {
+    color: var(--color-grey-light);
+  }
+
+  &--grey {
+    color: var(--color-grey);
+  }
+
+  &--grey-dark {
+    color: var(--color-grey-dark);
+  }
+
+  &--grey-darkest {
+    color: var(--color-grey-darkest);
+  }
+
+  &--green-light {
+    color: var(--color-green-light);
+  }
+
+  &--green-medium {
+    color: var(--color-green-medium);
+  }
+
+  &--green {
+    color: var(--color-green);
+  }
+
+  &--green-dark {
+    color: var(--color-green-dark);
+  }
+
+  &--pink {
+    color: var(--color-pink);
+  }
+
+  &--red {
+    color: var(--color-red);
+  }
+
+  &--orange {
+    color: var(--color-orange);
+  }
+
+  &--purple {
+    color: var(--color-purple);
+  }
+
+  &--blue {
+    color: var(--color-blue);
+  }
+
+  &--cyan {
+    color: var(--color-cyan);
+  }
+
+  &--brown {
+    color: var(--color-brown);
+  }
+
+  &--yellow {
+    color: var(--color-yellow);
+  }
+
+  &--primary {
+    color: var(--color-green);
+  }
+}

--- a/tokens/colors.json
+++ b/tokens/colors.json
@@ -5,94 +5,89 @@
   },
   "props": [
     {
-      "name": "COLOR_BRAND_WHITE",
+      "name": "COLOR_WHITE",
       "value": "#FFFFFF",
-      "comment": "Brand color white"
+      "comment": "color white"
     },
     {
-      "name": "COLOR_BRAND_GREY_LIGHT",
+      "name": "COLOR_GREY_LIGHT",
       "value": "#F5F6F9",
-      "comment": "Brand color grey light"
+      "comment": "color grey light"
     },
     {
-      "name": "COLOR_BRAND_GREY",
+      "name": "COLOR_GREY",
       "value": "#C9CFDD",
-      "comment": "Brand color grey"
+      "comment": "color grey"
     },
     {
-      "name": "COLOR_BRAND_DARK",
+      "name": "COLOR_GREY_DARK",
       "value": "#6B7B96",
-      "comment": "Brand color dark"
+      "comment": "color dark"
     },
     {
-      "name": "COLOR_BRAND_DARKEST",
+      "name": "COLOR_GREY_DARKEST",
       "value": "#011940",
-      "comment": "Brand color darkest"
+      "comment": "color darkest"
     },
     {
-      "name": "COLOR_BRAND_GREEN_LIGHT",
+      "name": "COLOR_GREEN_LIGHT",
       "value": "#CEF1E4",
-      "comment": "Brand color green light"
+      "comment": "color green light"
     },
     {
-      "name": "COLOR_BRAND_GREEN_MEDIUM",
+      "name": "COLOR_GREEN_MEDIUM",
       "value": "#9DE3C8",
-      "comment": "Brand color green medium"
+      "comment": "color green medium"
     },
     {
-      "name": "COLOR_BRAND_GREEN",
+      "name": "COLOR_GREEN",
       "value": "#09BA76",
-      "comment": "Brand color green"
+      "comment": "color green"
     },
     {
-      "name": "COLOR_BRAND_GREEN_DARK",
+      "name": "COLOR_GREEN_DARK",
       "value": "#069961",
-      "comment": "Brand color green_dark"
+      "comment": "color green_dark"
     },
     {
-      "name": "COLOR_THEME_GREEN",
-      "value": "#09BA76",
-      "comment": "Theme color Green"
-    },
-    {
-      "name": "COLOR_THEME_PINK",
+      "name": "COLOR_PINK",
       "value": "#FF6A9C",
-      "comment": "Theme color Pink"
+      "comment": "color Pink"
     },
     {
-      "name": "COLOR_THEME_RED",
+      "name": "COLOR_RED",
       "value": "#D20325",
-      "comment": "Theme color Red"
+      "comment": "color Red"
     },
     {
-      "name": "COLOR_THEME_ORANGE",
+      "name": "COLOR_ORANGE",
       "value": "#F35320",
-      "comment": "Theme color Orange"
+      "comment": "color Orange"
     },
     {
-      "name": "COLOR_THEME_PURPLE",
+      "name": "COLOR_PURPLE",
       "value": "#7826A2",
-      "comment": "Theme color purple"
+      "comment": "color purple"
     },
     {
-      "name": "COLOR_THEME_BLUE",
+      "name": "COLOR_BLUE",
       "value": "#2166CD",
-      "comment": "Theme color Blue"
+      "comment": "color Blue"
     },
     {
-      "name": "COLOR_THEME_CYAN",
+      "name": "COLOR_CYAN",
       "value": "#029B9B",
-      "comment": "Theme color Cyan"
+      "comment": "color Cyan"
     },
     {
-      "name": "COLOR_THEME_BROWN",
+      "name": "COLOR_BROWN",
       "value": "#8E523D",
-      "comment": "Theme color brown"
+      "comment": "color brown"
     },
     {
-      "name": "COLOR_THEME_YELLOW",
+      "name": "COLOR_YELLOW",
       "value": "#F8A221",
-      "comment": "Theme color Yellow"
+      "comment": "color Yellow"
     }
   ]
 }


### PR DESCRIPTION
This houses a couple of changes:

* Add utilities for background colors
* Add utilities for text colors
* Remove prefixes for coloring

Since we believe that green in brand will be the same as green in theme
we decided to remove the prefix for now. If we at a later point notice
it is needed, we can always add it back.