### PR TITLE
Remove !important from visibility utilities

### DIFF
--- a/src/utils/visibility.css
+++ b/src/utils/visibility.css
@@ -1,7 +1,7 @@
 .u-visible {
-  visibility: visible !important;
+  visibility: visible;
 }
 
 .u-invisible {
-  visibility: hidden !important;
+  visibility: hidden;
 }


### PR DESCRIPTION
We want to try and use !important as little as possible. Let's see how
well it works on the `visibility` utilities