### PR TITLE
Add @extend functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "husky": "^3.0.4",
     "lint-staged": "^9.2.3",
     "postcss-cli": "^6.1.3",
+    "postcss-extend-rule": "^3.0.0",
     "postcss-import": "^12.0.1",
     "postcss-nested": "^4.1.2",
     "postcss-preset-env": "^6.7.0",
@@ -39,7 +40,7 @@
       "git add"
     ],
     "*.css": [
-      "stylelint --fix",
+      "stylelint --config stylelint.config.js --fix",
       "git add"
     ]
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,6 +5,7 @@ module.exports = {
     }),
     require("postcss-preset-env")(),
     require("postcss-nested"),
+    require("postcss-extend-rule"),
     require("postcss-reporter")({ clearReportedMessages: true })
   ]
 }

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -1,10 +1,10 @@
 .c-button {
+  @extend .u-bg--white, .u-text--grey-darkest;
+
   display: inline-block;
   border: 1px solid var(--color-border-dark);
   border-radius: var(--border-radius);
   outline: none;
-  background-color: var(--color-white);
-  color: var(--color-grey-darkest);
   font-weight: 500;
   line-height: calc(1em - 1px);
   text-align: center;
@@ -33,37 +33,37 @@
   }
 
   &--primary {
+    @extend .u-bg--green, .u-text--white;
+
     border-color: var(--color-green);
-    background-color: var(--color-green);
-    color: var(--color-white);
   }
 
   &--primary:hover {
+    @extend .u-bg--green-dark;
+
     border-color: var(--color-green-dark);
-    background-color: var(--color-green-dark);
   }
 
   &--subtle {
+    @extend .u-bg--green-light, .u-text--green;
+
     border-color: var(--color-green-light);
-    background-color: var(--color-green-light);
-    color: var(--color-green);
   }
 
   &--subtle:hover {
+    @extend .u-bg--green-medium, .u-text-green-dark;
+
     border-color: var(--color-green-medium);
-    background-color: var(--color-green-medium);
-    color: var(--color-green-dark);
   }
 
   &--secondary {
+    @extend .u-bg-white, .u-text-grey-dark;
+
     border-color: var(--color-border-dark);
-    background-color: var(--color-white);
-    color: var(--color-grey-dark);
   }
 
   &--secondary:hover {
-    background-color: var(--color-grey-light);
-    color: var(--color-grey-darkest);
+    @extend .u-bg--grey-light, .u-text-grey-darkest;
   }
 
   &:not(.is-disabled) {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,4 +1,12 @@
 module.exports = {
+  rules: {
+    "at-rule-no-unknown": [
+      true,
+      {
+        ignoreAtRules: ["extend"]
+      }
+    ]
+  },
   extends: [
     "stylelint-config-standard",
     "stylelint-config-property-sort-order-smacss"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,6 +3598,15 @@ postcss-env-function@^2.0.2:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
+postcss-extend-rule@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-extend-rule/-/postcss-extend-rule-3.0.0.tgz#d6ee2fb24ab2b3d9b50acce1d055c1c137ab5f44"
+  integrity sha512-gMlRmW52Y86Lct+KTr+gMjxk0aUSuTyjtvelIH3a7UdaXONaKH6qSmj8KAXCW4+nhTlAsOw5JdkRjCdZ/Kjb3Q==
+  dependencies:
+    postcss "^7.0.17"
+    postcss-nesting "^7.0.1"
+    postcss-tape "^5.0.2"
+
 postcss-focus-visible@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz#477d107113ade6024b14128317ade2bd1e17046e"
@@ -3725,7 +3734,7 @@ postcss-nested@^4.1.2:
     postcss "^7.0.14"
     postcss-selector-parser "^5.0.0"
 
-postcss-nesting@^7.0.0:
+postcss-nesting@^7.0.0, postcss-nesting@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-7.0.1.tgz#b50ad7b7f0173e5b5e3880c3501344703e04c052"
   integrity sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==
@@ -3895,6 +3904,11 @@ postcss-syntax@^0.36.2:
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz#f08578c7d95834574e5593a82dfbfa8afae3b51c"
   integrity sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==
+
+postcss-tape@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-tape/-/postcss-tape-5.0.2.tgz#7ae011050954fdc10b17d1f1551c9d9bf14e4bdf"
+  integrity sha512-e4770WnsUzczQp/pAIsz0s0MDLAQ7luyh1/hs8QBcdfXOMrz0siEqYNHAKJIoCvGtLoi2QUjWASvTbPfyTfIWg==
 
 postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
PostCSS does not support extending classes out of the box. By adding thr
`postcss-extend-rule` plugin we can now use this.

Biggest benefit here is that we can use our utilities in our CSS, so we
can actually compose components out of existing utilities. This becomes
really powerful when we need to use things like spacing and margin.

I couldn't get the Stylelinter to work that no newline was needed after the `@extend`. @xadamy would you have any suggestions on how to get that working? (No blocker for me)