### PR TITLE
DL: Add responsive grid

### DIFF
--- a/src/generated/index.custom-properties.css
+++ b/src/generated/index.custom-properties.css
@@ -104,4 +104,16 @@
 
   /* Huge padding we can use for seperation of vertical sections */
   --spacing-xxx-large: 11.4rem;
+
+  /* Small breakpoint */
+  --break-small: 25rem;
+
+  /* Small breakpoint */
+  --break-medium: 40rem;
+
+  /* Small breakpoint */
+  --break-large: 60rem;
+
+  /* Small breakpoint */
+  --break-extra-large: 75rem;
 }

--- a/src/objects/grid.css
+++ b/src/objects/grid.css
@@ -1,9 +1,10 @@
+.o-grid-3-2-1 {
+  grid-gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
 .o-grid {
   display: grid;
-  grid-column-gap: var(--spacing-grid-gutter);
-  grid-row-gap: 1rem;
-
-  @media (min-width: 75rem) {
-    grid-template-columns: repeat(12, 1fr);
-  }
+  grid-gap: var(--spacing-grid-gutter);
+  grid-template-columns: repeat(12, 1fr);
 }

--- a/src/objects/grid.css
+++ b/src/objects/grid.css
@@ -2,9 +2,4 @@
   display: grid;
   grid-gap: var(--spacing-grid-gutter);
   grid-template-columns: repeat(12, 1fr);
-
-  &--3-2-1 {
-    grid-gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  }
 }

--- a/src/objects/grid.css
+++ b/src/objects/grid.css
@@ -1,10 +1,10 @@
-.o-grid-3-2-1 {
-  grid-gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
 .o-grid {
   display: grid;
   grid-gap: var(--spacing-grid-gutter);
   grid-template-columns: repeat(12, 1fr);
+
+  &--3-2-1 {
+    grid-gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
 }

--- a/src/utils/grid.css
+++ b/src/utils/grid.css
@@ -1,3 +1,201 @@
+.u-1\/12 {
+  grid-column: span 1;
+}
+
+.u-2\/12 {
+  grid-column: span 2;
+}
+
+.u-3\/12 {
+  grid-column: span 3;
+}
+
+.u-4\/12 {
+  grid-column: span 4;
+}
+
+.u-5\/12 {
+  grid-column: span 5;
+}
+
+.u-6\/12 {
+  grid-column: span 6;
+}
+
+.u-7\/12 {
+  grid-column: span 7;
+}
+
+.u-8\/12 {
+  grid-column: span 8;
+}
+
+.u-9\/12 {
+  grid-column: span 9;
+}
+
+.u-10\/12 {
+  grid-column: span 10;
+}
+
+.u-11\/12 {
+  grid-column: span 11;
+}
+
+.u-12\/12 {
+  grid-column: span 12;
+}
+
+@media (min-width: 25rem) {
+  .u-1\/12\@sm {
+    grid-column: span 1;
+  }
+
+  .u-2\/12\@sm {
+    grid-column: span 2;
+  }
+
+  .u-3\/12\@sm {
+    grid-column: span 3;
+  }
+
+  .u-4\/12\@sm {
+    grid-column: span 4;
+  }
+
+  .u-5\/12\@sm {
+    grid-column: span 5;
+  }
+
+  .u-6\/12\@sm {
+    grid-column: span 6;
+  }
+
+  .u-7\/12\@sm {
+    grid-column: span 7;
+  }
+
+  .u-8\/12\@sm {
+    grid-column: span 8;
+  }
+
+  .u-9\/12\@sm {
+    grid-column: span 9;
+  }
+
+  .u-10\/12\@sm {
+    grid-column: span 10;
+  }
+
+  .u-11\/12\@sm {
+    grid-column: span 11;
+  }
+
+  .u-12\/12\@sm {
+    grid-column: span 12;
+  }
+}
+
+@media (min-width: 40rem) {
+  .u-1\/12\@md {
+    grid-column: span 1;
+  }
+
+  .u-2\/12\@md {
+    grid-column: span 2;
+  }
+
+  .u-3\/12\@md {
+    grid-column: span 3;
+  }
+
+  .u-4\/12\@md {
+    grid-column: span 4;
+  }
+
+  .u-5\/12\@md {
+    grid-column: span 5;
+  }
+
+  .u-6\/12\@md {
+    grid-column: span 6;
+  }
+
+  .u-7\/12\@md {
+    grid-column: span 7;
+  }
+
+  .u-8\/12\@md {
+    grid-column: span 8;
+  }
+
+  .u-9\/12\@md {
+    grid-column: span 9;
+  }
+
+  .u-10\/12\@md {
+    grid-column: span 10;
+  }
+
+  .u-11\/12\@md {
+    grid-column: span 11;
+  }
+
+  .u-12\/12\@md {
+    grid-column: span 12;
+  }
+}
+
+@media (min-width: 60rem) {
+  .u-1\/12\@lg {
+    grid-column: span 1;
+  }
+
+  .u-2\/12\@lg {
+    grid-column: span 2;
+  }
+
+  .u-3\/12\@lg {
+    grid-column: span 3;
+  }
+
+  .u-4\/12\@lg {
+    grid-column: span 4;
+  }
+
+  .u-5\/12\@lg {
+    grid-column: span 5;
+  }
+
+  .u-6\/12\@lg {
+    grid-column: span 6;
+  }
+
+  .u-7\/12\@lg {
+    grid-column: span 7;
+  }
+
+  .u-8\/12\@lg {
+    grid-column: span 8;
+  }
+
+  .u-9\/12\@lg {
+    grid-column: span 9;
+  }
+
+  .u-10\/12\@lg {
+    grid-column: span 10;
+  }
+
+  .u-11\/12\@lg {
+    grid-column: span 11;
+  }
+
+  .u-12\/12\@lg {
+    grid-column: span 12;
+  }
+}
+
 @media (min-width: 75rem) {
   .u-1\/12\@xl {
     grid-column: span 1;

--- a/src/utils/grid.css
+++ b/src/utils/grid.css
@@ -1,247 +1,247 @@
-.u-1\/12 {
+.u-grid-1\/12 {
   grid-column: span 1;
 }
 
-.u-2\/12 {
+.u-grid-2\/12 {
   grid-column: span 2;
 }
 
-.u-3\/12 {
+.u-grid-3\/12 {
   grid-column: span 3;
 }
 
-.u-4\/12 {
+.u-grid-4\/12 {
   grid-column: span 4;
 }
 
-.u-5\/12 {
+.u-grid-5\/12 {
   grid-column: span 5;
 }
 
-.u-6\/12 {
+.u-grid-6\/12 {
   grid-column: span 6;
 }
 
-.u-7\/12 {
+.u-grid-7\/12 {
   grid-column: span 7;
 }
 
-.u-8\/12 {
+.u-grid-8\/12 {
   grid-column: span 8;
 }
 
-.u-9\/12 {
+.u-grid-9\/12 {
   grid-column: span 9;
 }
 
-.u-10\/12 {
+.u-grid-10\/12 {
   grid-column: span 10;
 }
 
-.u-11\/12 {
+.u-grid-11\/12 {
   grid-column: span 11;
 }
 
-.u-12\/12 {
+.u-grid-12\/12 {
   grid-column: span 12;
 }
 
 @media (min-width: 25rem) {
-  .u-1\/12\@sm {
+  .u-grid-1\/12\@sm {
     grid-column: span 1;
   }
 
-  .u-2\/12\@sm {
+  .u-grid-2\/12\@sm {
     grid-column: span 2;
   }
 
-  .u-3\/12\@sm {
+  .u-grid-3\/12\@sm {
     grid-column: span 3;
   }
 
-  .u-4\/12\@sm {
+  .u-grid-4\/12\@sm {
     grid-column: span 4;
   }
 
-  .u-5\/12\@sm {
+  .u-grid-5\/12\@sm {
     grid-column: span 5;
   }
 
-  .u-6\/12\@sm {
+  .u-grid-6\/12\@sm {
     grid-column: span 6;
   }
 
-  .u-7\/12\@sm {
+  .u-grid-7\/12\@sm {
     grid-column: span 7;
   }
 
-  .u-8\/12\@sm {
+  .u-grid-8\/12\@sm {
     grid-column: span 8;
   }
 
-  .u-9\/12\@sm {
+  .u-grid-9\/12\@sm {
     grid-column: span 9;
   }
 
-  .u-10\/12\@sm {
+  .u-grid-10\/12\@sm {
     grid-column: span 10;
   }
 
-  .u-11\/12\@sm {
+  .u-grid-11\/12\@sm {
     grid-column: span 11;
   }
 
-  .u-12\/12\@sm {
+  .u-grid-12\/12\@sm {
     grid-column: span 12;
   }
 }
 
 @media (min-width: 40rem) {
-  .u-1\/12\@md {
+  .u-grid-1\/12\@md {
     grid-column: span 1;
   }
 
-  .u-2\/12\@md {
+  .u-grid-2\/12\@md {
     grid-column: span 2;
   }
 
-  .u-3\/12\@md {
+  .u-grid-3\/12\@md {
     grid-column: span 3;
   }
 
-  .u-4\/12\@md {
+  .u-grid-4\/12\@md {
     grid-column: span 4;
   }
 
-  .u-5\/12\@md {
+  .u-grid-5\/12\@md {
     grid-column: span 5;
   }
 
-  .u-6\/12\@md {
+  .u-grid-6\/12\@md {
     grid-column: span 6;
   }
 
-  .u-7\/12\@md {
+  .u-grid-7\/12\@md {
     grid-column: span 7;
   }
 
-  .u-8\/12\@md {
+  .u-grid-8\/12\@md {
     grid-column: span 8;
   }
 
-  .u-9\/12\@md {
+  .u-grid-9\/12\@md {
     grid-column: span 9;
   }
 
-  .u-10\/12\@md {
+  .u-grid-10\/12\@md {
     grid-column: span 10;
   }
 
-  .u-11\/12\@md {
+  .u-grid-11\/12\@md {
     grid-column: span 11;
   }
 
-  .u-12\/12\@md {
+  .u-grid-12\/12\@md {
     grid-column: span 12;
   }
 }
 
 @media (min-width: 60rem) {
-  .u-1\/12\@lg {
+  .u-grid-1\/12\@lg {
     grid-column: span 1;
   }
 
-  .u-2\/12\@lg {
+  .u-grid-2\/12\@lg {
     grid-column: span 2;
   }
 
-  .u-3\/12\@lg {
+  .u-grid-3\/12\@lg {
     grid-column: span 3;
   }
 
-  .u-4\/12\@lg {
+  .u-grid-4\/12\@lg {
     grid-column: span 4;
   }
 
-  .u-5\/12\@lg {
+  .u-grid-5\/12\@lg {
     grid-column: span 5;
   }
 
-  .u-6\/12\@lg {
+  .u-grid-6\/12\@lg {
     grid-column: span 6;
   }
 
-  .u-7\/12\@lg {
+  .u-grid-7\/12\@lg {
     grid-column: span 7;
   }
 
-  .u-8\/12\@lg {
+  .u-grid-8\/12\@lg {
     grid-column: span 8;
   }
 
-  .u-9\/12\@lg {
+  .u-grid-9\/12\@lg {
     grid-column: span 9;
   }
 
-  .u-10\/12\@lg {
+  .u-grid-10\/12\@lg {
     grid-column: span 10;
   }
 
-  .u-11\/12\@lg {
+  .u-grid-11\/12\@lg {
     grid-column: span 11;
   }
 
-  .u-12\/12\@lg {
+  .u-grid-12\/12\@lg {
     grid-column: span 12;
   }
 }
 
 @media (min-width: 75rem) {
-  .u-1\/12\@xl {
+  .u-grid-1\/12\@xl {
     grid-column: span 1;
   }
 
-  .u-2\/12\@xl {
+  .u-grid-2\/12\@xl {
     grid-column: span 2;
   }
 
-  .u-3\/12\@xl {
+  .u-grid-3\/12\@xl {
     grid-column: span 3;
   }
 
-  .u-4\/12\@xl {
+  .u-grid-4\/12\@xl {
     grid-column: span 4;
   }
 
-  .u-5\/12\@xl {
+  .u-grid-5\/12\@xl {
     grid-column: span 5;
   }
 
-  .u-6\/12\@xl {
+  .u-grid-6\/12\@xl {
     grid-column: span 6;
   }
 
-  .u-7\/12\@xl {
+  .u-grid-7\/12\@xl {
     grid-column: span 7;
   }
 
-  .u-8\/12\@xl {
+  .u-grid-8\/12\@xl {
     grid-column: span 8;
   }
 
-  .u-9\/12\@xl {
+  .u-grid-9\/12\@xl {
     grid-column: span 9;
   }
 
-  .u-10\/12\@xl {
+  .u-grid-10\/12\@xl {
     grid-column: span 10;
   }
 
-  .u-11\/12\@xl {
+  .u-grid-11\/12\@xl {
     grid-column: span 11;
   }
 
-  .u-12\/12\@xl {
+  .u-grid-12\/12\@xl {
     grid-column: span 12;
   }
 }

--- a/tokens/spacing.json
+++ b/tokens/spacing.json
@@ -63,6 +63,26 @@
       "name": "SPACING_XXX_LARGE",
       "value": "11.4rem",
       "comment": "Huge padding we can use for seperation of vertical sections"
+    },
+    {
+      "name": "BREAK_SMALL",
+      "value": "25rem",
+      "comment": "Small breakpoint"
+    },
+    {
+      "name": "BREAK_MEDIUM",
+      "value": "40rem",
+      "comment": "Small breakpoint"
+    },
+    {
+      "name": "BREAK_LARGE",
+      "value": "60rem",
+      "comment": "Small breakpoint"
+    },
+    {
+      "name": "BREAK_EXTRA_LARGE",
+      "value": "75rem",
+      "comment": "Small breakpoint"
     }
   ]
 }


### PR DESCRIPTION
This close #33 

I chose for a responsive grid where the # of columns does not change, but rather the responsiveness is decided in the columns. This gives us the most flexibility to maintain 3/4/6 column layouts at smallers sizes. It does requires us to be a bit more verbose in the assignment of columns.

I also removed the `3-2-1` automatic grid. Although it worked very well, it broke at different breakpoints than those we manually specified.