### PR TITLE
Make Husky Stylelinting follow our rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,json,md}": [
+    "*.{js,json,md}": [
       "prettier --write",
       "git add"
     ],
     "*.css": [
-      "stylelint --config stylelint.config.js --fix",
+      "stylelint --config stylelint.config.js",
       "git add"
     ]
   },

--- a/src/generated/index.custom-properties.css
+++ b/src/generated/index.custom-properties.css
@@ -1,62 +1,46 @@
+
 :root {
   --border-radius-small: 4px;
   --border-radius: 8px;
   --border-radius-large: 12px;
   --border-radius-circle: 50%;
-  --color-border-separator: #c9cfdd;
-  --color-border-dark: #c9cfdd;
-  --color-border: #f5f6f9;
-
+  --color-border-separator: #C9CFDD;
+  --color-border-dark: #C9CFDD;
+  --color-border: #F5F6F9;
   /* color white */
-  --color-white: #fff;
-
+  --color-white: #FFFFFF;
   /* color grey light */
-  --color-grey-light: #f5f6f9;
-
+  --color-grey-light: #F5F6F9;
   /* color grey */
-  --color-grey: #c9cfdd;
-
+  --color-grey: #C9CFDD;
   /* color dark */
-  --color-grey-dark: #6b7b96;
-
+  --color-grey-dark: #6B7B96;
   /* color darkest */
   --color-grey-darkest: #011940;
-
   /* color green light */
-  --color-green-light: #cef1e4;
-
+  --color-green-light: #CEF1E4;
   /* color green medium */
-  --color-green-medium: #9de3c8;
-
+  --color-green-medium: #9DE3C8;
   /* color green */
-  --color-green: #09ba76;
-
+  --color-green: #09BA76;
   /* color green_dark */
   --color-green-dark: #069961;
-
   /* color Pink */
-  --color-pink: #ff6a9c;
-
+  --color-pink: #FF6A9C;
   /* color Red */
-  --color-red: #d20325;
-
+  --color-red: #D20325;
   /* color Orange */
-  --color-orange: #f35320;
-
+  --color-orange: #F35320;
   /* color purple */
-  --color-purple: #7826a2;
-
+  --color-purple: #7826A2;
   /* color Blue */
-  --color-blue: #2166cd;
-
+  --color-blue: #2166CD;
   /* color Cyan */
-  --color-cyan: #029b9b;
-
+  --color-cyan: #029B9B;
   /* color brown */
-  --color-brown: #8e523d;
-
+  --color-brown: #8E523D;
   /* color Yellow */
-  --color-yellow: #f8a221;
+  --color-yellow: #F8A221;
   --font-size-tiny: 0.64rem;
   --font-size-small: 0.8rem;
   --font-size-root: 16px;
@@ -68,52 +52,36 @@
   --font-size-xxx-large: 3.052rem;
   --default: Museo Sans Rounded;
   --monospaced: Alma Mono;
-
   /* Grid gutter size */
   --spacing-grid-gutter: 1.5rem;
-
   /* Grid outside margin */
   --spacing-grid-margin: 2.25rem;
-
   /* Grid column size */
   --spacing-grid-column: 45rem;
-
   /* For micro adjustments */
   --spacing-xx-small: 0.444rem;
-
   /* For micro adjustments */
   --spacing-x-small: 0.667rem;
-
   /* For paddings in labels / inline stuff */
   --spacing-small: 1rem;
-
   /* Regular padding for compact tables and such. */
   --spacing-normal: 1.5rem;
-
   /* For paddings in labels / inline stuff */
   --spacing-medium: 2.25rem;
-
   /* Padding for the inside of boxes */
   --spacing-large: 3.375rem;
-
   /* Padding between elements and for boxes with larger font-sizes */
   --spacing-x-large: 5.0625rem;
-
   /* Larger padding for when bigger spacing is needed */
   --spacing-xx-large: 7.6rem;
-
   /* Huge padding we can use for seperation of vertical sections */
   --spacing-xxx-large: 11.4rem;
-
   /* Small breakpoint */
   --break-small: 25rem;
-
   /* Small breakpoint */
   --break-medium: 40rem;
-
   /* Small breakpoint */
   --break-large: 60rem;
-
   /* Small breakpoint */
   --break-extra-large: 75rem;
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,7 +5,10 @@ module.exports = {
       {
         ignoreAtRules: ["extend"]
       }
-    ]
+    ],
+    "color-hex-case": "upper",
+    "color-hex-length": "long",
+    "comment-empty-line-before": null
   },
   extends: [
     "stylelint-config-standard",


### PR DESCRIPTION
Currently the Husky Stylelinting was conflicting with the Prettier
plugin. They both did something different.

Now prettier doesn't touch CSS anymore, and stylelint is actually
enforcing our CSS rules.

This is also checked in our CI to block builds if needed.

To make sure people only commit code that they actually wanted to commit
I removed the `--fix` flag. If we run into reasons we want to auto-fix
it, we can add it back