### PR TITLE
Add @responsive helper to generate responsive CSS

### DIFF
--- a/plugins/atResponsive.js
+++ b/plugins/atResponsive.js
@@ -1,0 +1,50 @@
+var postcss = require("postcss")
+
+function convertBreakPointsInRules(breakpoints) {
+  return breakpoints.map(breakpoint => {
+    const processedBreakpoint = Object.assign({}, breakpoint)
+    let atRule = postcss.atRule({
+      name: "media",
+      params: `(min-width: ${processedBreakpoint.breakpoint})`
+    })
+
+    processedBreakpoint.atRule = atRule
+    return processedBreakpoint
+  })
+}
+
+module.exports = postcss.plugin("atResponsive", function(opts) {
+  opts = opts || {}
+
+  return function(root, result) {
+    root.walkAtRules("responsive", atRule => {
+      const rules = atRule.nodes
+
+      const breakpointRules = convertBreakPointsInRules(opts.breakpoints)
+
+      rules.forEach(rule => {
+        const startOfResponsiveBlock = rule.parent.parent
+        const clone = rule.clone()
+        startOfResponsiveBlock.insertBefore(rule.parent, clone)
+
+        breakpointRules.forEach(breakpoint => {
+          const newRule = rule.clone({
+            selector: `.${breakpoint.name}${
+              opts.divider
+            }${rule.selector.substring(1)}`
+          })
+          breakpoint.atRule.append(newRule)
+        })
+      })
+
+      root.insertAfter(
+        atRule,
+        breakpointRules.map(breakpoint => {
+          return breakpoint.atRule
+        })
+      )
+
+      atRule.remove()
+    })
+  }
+})

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,6 +6,15 @@ module.exports = {
     require("postcss-preset-env")(),
     require("postcss-nested"),
     require("postcss-extend-rule"),
-    require("postcss-reporter")({ clearReportedMessages: true })
+    require("postcss-reporter")({ clearReportedMessages: true }),
+    require("./plugins/atResponsive.js")({
+      divider: "\\:",
+      breakpoints: [
+        { name: "sm", breakpoint: "25rem" },
+        { name: "md", breakpoint: "40rem" },
+        { name: "lg", breakpoint: "60rem" },
+        { name: "xlg", breakpoint: "75rem" }
+      ]
+    })
   ]
 }

--- a/src/utils/grid.css
+++ b/src/utils/grid.css
@@ -1,49 +1,49 @@
 @responsive {
-  .u-grid-1\/12 {
+  .u-grid-1 {
     grid-column: span 1;
   }
 
-  .u-grid-2\/12 {
+  .u-grid-2 {
     grid-column: span 2;
   }
 
-  .u-grid-3\/12 {
+  .u-grid-3 {
     grid-column: span 3;
   }
 
-  .u-grid-4\/12 {
+  .u-grid-4 {
     grid-column: span 4;
   }
 
-  .u-grid-5\/12 {
+  .u-grid-5 {
     grid-column: span 5;
   }
 
-  .u-grid-6\/12 {
+  .u-grid-6 {
     grid-column: span 6;
   }
 
-  .u-grid-7\/12 {
+  .u-grid-7 {
     grid-column: span 7;
   }
 
-  .u-grid-8\/12 {
+  .u-grid-8 {
     grid-column: span 8;
   }
 
-  .u-grid-9\/12 {
+  .u-grid-9 {
     grid-column: span 9;
   }
 
-  .u-grid-10\/12 {
+  .u-grid-10 {
     grid-column: span 10;
   }
 
-  .u-grid-11\/12 {
+  .u-grid-11 {
     grid-column: span 11;
   }
 
-  .u-grid-12\/12 {
+  .u-grid-12 {
     grid-column: span 12;
   }
 }

--- a/src/utils/grid.css
+++ b/src/utils/grid.css
@@ -1,247 +1,49 @@
-.u-grid-1\/12 {
-  grid-column: span 1;
-}
-
-.u-grid-2\/12 {
-  grid-column: span 2;
-}
-
-.u-grid-3\/12 {
-  grid-column: span 3;
-}
-
-.u-grid-4\/12 {
-  grid-column: span 4;
-}
-
-.u-grid-5\/12 {
-  grid-column: span 5;
-}
-
-.u-grid-6\/12 {
-  grid-column: span 6;
-}
-
-.u-grid-7\/12 {
-  grid-column: span 7;
-}
-
-.u-grid-8\/12 {
-  grid-column: span 8;
-}
-
-.u-grid-9\/12 {
-  grid-column: span 9;
-}
-
-.u-grid-10\/12 {
-  grid-column: span 10;
-}
-
-.u-grid-11\/12 {
-  grid-column: span 11;
-}
-
-.u-grid-12\/12 {
-  grid-column: span 12;
-}
-
-@media (min-width: 25rem) {
-  .u-grid-1\/12\@sm {
+@responsive {
+  .u-grid-1\/12 {
     grid-column: span 1;
   }
 
-  .u-grid-2\/12\@sm {
+  .u-grid-2\/12 {
     grid-column: span 2;
   }
 
-  .u-grid-3\/12\@sm {
+  .u-grid-3\/12 {
     grid-column: span 3;
   }
 
-  .u-grid-4\/12\@sm {
+  .u-grid-4\/12 {
     grid-column: span 4;
   }
 
-  .u-grid-5\/12\@sm {
+  .u-grid-5\/12 {
     grid-column: span 5;
   }
 
-  .u-grid-6\/12\@sm {
+  .u-grid-6\/12 {
     grid-column: span 6;
   }
 
-  .u-grid-7\/12\@sm {
+  .u-grid-7\/12 {
     grid-column: span 7;
   }
 
-  .u-grid-8\/12\@sm {
+  .u-grid-8\/12 {
     grid-column: span 8;
   }
 
-  .u-grid-9\/12\@sm {
+  .u-grid-9\/12 {
     grid-column: span 9;
   }
 
-  .u-grid-10\/12\@sm {
+  .u-grid-10\/12 {
     grid-column: span 10;
   }
 
-  .u-grid-11\/12\@sm {
+  .u-grid-11\/12 {
     grid-column: span 11;
   }
 
-  .u-grid-12\/12\@sm {
-    grid-column: span 12;
-  }
-}
-
-@media (min-width: 40rem) {
-  .u-grid-1\/12\@md {
-    grid-column: span 1;
-  }
-
-  .u-grid-2\/12\@md {
-    grid-column: span 2;
-  }
-
-  .u-grid-3\/12\@md {
-    grid-column: span 3;
-  }
-
-  .u-grid-4\/12\@md {
-    grid-column: span 4;
-  }
-
-  .u-grid-5\/12\@md {
-    grid-column: span 5;
-  }
-
-  .u-grid-6\/12\@md {
-    grid-column: span 6;
-  }
-
-  .u-grid-7\/12\@md {
-    grid-column: span 7;
-  }
-
-  .u-grid-8\/12\@md {
-    grid-column: span 8;
-  }
-
-  .u-grid-9\/12\@md {
-    grid-column: span 9;
-  }
-
-  .u-grid-10\/12\@md {
-    grid-column: span 10;
-  }
-
-  .u-grid-11\/12\@md {
-    grid-column: span 11;
-  }
-
-  .u-grid-12\/12\@md {
-    grid-column: span 12;
-  }
-}
-
-@media (min-width: 60rem) {
-  .u-grid-1\/12\@lg {
-    grid-column: span 1;
-  }
-
-  .u-grid-2\/12\@lg {
-    grid-column: span 2;
-  }
-
-  .u-grid-3\/12\@lg {
-    grid-column: span 3;
-  }
-
-  .u-grid-4\/12\@lg {
-    grid-column: span 4;
-  }
-
-  .u-grid-5\/12\@lg {
-    grid-column: span 5;
-  }
-
-  .u-grid-6\/12\@lg {
-    grid-column: span 6;
-  }
-
-  .u-grid-7\/12\@lg {
-    grid-column: span 7;
-  }
-
-  .u-grid-8\/12\@lg {
-    grid-column: span 8;
-  }
-
-  .u-grid-9\/12\@lg {
-    grid-column: span 9;
-  }
-
-  .u-grid-10\/12\@lg {
-    grid-column: span 10;
-  }
-
-  .u-grid-11\/12\@lg {
-    grid-column: span 11;
-  }
-
-  .u-grid-12\/12\@lg {
-    grid-column: span 12;
-  }
-}
-
-@media (min-width: 75rem) {
-  .u-grid-1\/12\@xl {
-    grid-column: span 1;
-  }
-
-  .u-grid-2\/12\@xl {
-    grid-column: span 2;
-  }
-
-  .u-grid-3\/12\@xl {
-    grid-column: span 3;
-  }
-
-  .u-grid-4\/12\@xl {
-    grid-column: span 4;
-  }
-
-  .u-grid-5\/12\@xl {
-    grid-column: span 5;
-  }
-
-  .u-grid-6\/12\@xl {
-    grid-column: span 6;
-  }
-
-  .u-grid-7\/12\@xl {
-    grid-column: span 7;
-  }
-
-  .u-grid-8\/12\@xl {
-    grid-column: span 8;
-  }
-
-  .u-grid-9\/12\@xl {
-    grid-column: span 9;
-  }
-
-  .u-grid-10\/12\@xl {
-    grid-column: span 10;
-  }
-
-  .u-grid-11\/12\@xl {
-    grid-column: span 11;
-  }
-
-  .u-grid-12\/12\@xl {
+  .u-grid-12\/12 {
     grid-column: span 12;
   }
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,7 +3,7 @@ module.exports = {
     "at-rule-no-unknown": [
       true,
       {
-        ignoreAtRules: ["extend"]
+        ignoreAtRules: ["extend", "responsive"]
       }
     ],
     "color-hex-case": "upper",


### PR DESCRIPTION
When creating utilities you sometimes want to have them generated in a
couple of variants for different screens. To prevent we have to do all
of this by hand I created a @responsive helper that you can use to wrap
the css in. All the classes inside that block will then get the
proper breakpoints generated. Keep in mind that the original block will
also always remain present.