### PR TITLE
Convert utilities to non-bem

### DIFF
--- a/src/components/button.css
+++ b/src/components/button.css
@@ -1,5 +1,5 @@
 .c-button {
-  @extend .u-bg--white, .u-t--grey-darkest;
+  @extend .u-bg-white, .u-t-grey-darkest;
 
   display: inline-block;
   border: 1px solid var(--color-border-dark);
@@ -33,25 +33,25 @@
   }
 
   &--primary {
-    @extend .u-bg--green, .u-t--white;
+    @extend .u-bg-green, .u-t-white;
 
     border-color: var(--color-green);
   }
 
   &--primary:hover {
-    @extend .u-bg--green-dark;
+    @extend .u-bg-green-dark;
 
     border-color: var(--color-green-dark);
   }
 
   &--subtle {
-    @extend .u-bg--green-light, .u-t--green;
+    @extend .u-bg-green-light, .u-t-green;
 
     border-color: var(--color-green-light);
   }
 
   &--subtle:hover {
-    @extend .u-bg--green-medium, .u-text-green-dark;
+    @extend .u-bg-green-medium, .u-text-green-dark;
 
     border-color: var(--color-green-medium);
   }
@@ -63,7 +63,7 @@
   }
 
   &--secondary:hover {
-    @extend .u-bg--grey-light, .u-text-grey-darkest;
+    @extend .u-bg-grey-light, .u-text-grey-darkest;
   }
 
   &:not(.is-disabled) {

--- a/src/components/navigation.css
+++ b/src/components/navigation.css
@@ -8,12 +8,13 @@
   }
 
   &__link {
+    @extend .u-t-grey-dark;
+
     display: block;
-    color: var(--color-grey-dark);
     text-decoration: none;
   }
 
   &__link:hover {
-    color: var(--color-grey-darkest);
+    @extend .u-t-grey-darkest;
   }
 }

--- a/src/components/topbar.css
+++ b/src/components/topbar.css
@@ -3,10 +3,10 @@
   border-bottom: 1px solid var(--color-grey);
 
   &__logo {
-    margin-right: var(--spacing-large);
+    @extend .u-mr-lg;
   }
 
   &__login {
-    margin-left: auto;
+    @extend .u-ml-auto;
   }
 }

--- a/src/utils/bg-color.css
+++ b/src/utils/bg-color.css
@@ -1,73 +1,71 @@
-.u-bg {
-  &--white {
-    background: var(--color-white);
-  }
+.u-bg-white {
+  background: var(--color-white);
+}
 
-  &--grey-light {
-    background: var(--color-grey-light);
-  }
+.u-bg-grey-light {
+  background: var(--color-grey-light);
+}
 
-  &--grey {
-    background: var(--color-grey);
-  }
+.u-bg-grey {
+  background: var(--color-grey);
+}
 
-  &--grey-dark {
-    background: var(--color-grey-dark);
-  }
+.u-bg-grey-dark {
+  background: var(--color-grey-dark);
+}
 
-  &--grey-darkest {
-    background: var(--color-grey-darkest);
-  }
+.u-bg-grey-darkest {
+  background: var(--color-grey-darkest);
+}
 
-  &--green-light {
-    background: var(--color-green-light);
-  }
+.u-bg-green-light {
+  background: var(--color-green-light);
+}
 
-  &--green-medium {
-    background: var(--color-green-medium);
-  }
+.u-bg-green-medium {
+  background: var(--color-green-medium);
+}
 
-  &--green {
-    background: var(--color-green);
-  }
+.u-bg-green {
+  background: var(--color-green);
+}
 
-  &--green-dark {
-    background: var(--color-green-dark);
-  }
+.u-bg-green-dark {
+  background: var(--color-green-dark);
+}
 
-  &--pink {
-    background: var(--color-pink);
-  }
+.u-bg-pink {
+  background: var(--color-pink);
+}
 
-  &--red {
-    background: var(--color-red);
-  }
+.u-bg-red {
+  background: var(--color-red);
+}
 
-  &--orange {
-    background: var(--color-orange);
-  }
+.u-bg-orange {
+  background: var(--color-orange);
+}
 
-  &--purple {
-    background: var(--color-purple);
-  }
+.u-bg-purple {
+  background: var(--color-purple);
+}
 
-  &--blue {
-    background: var(--color-blue);
-  }
+.u-bg-blue {
+  background: var(--color-blue);
+}
 
-  &--cyan {
-    background: var(--color-cyan);
-  }
+.u-bg-cyan {
+  background: var(--color-cyan);
+}
 
-  &--brown {
-    background: var(--color-brown);
-  }
+.u-bg-brown {
+  background: var(--color-brown);
+}
 
-  &--yellow {
-    background: var(--color-yellow);
-  }
+.u-bg-yellow {
+  background: var(--color-yellow);
+}
 
-  &--primary {
-    background: var(--color-green);
-  }
+.u-bg-primary {
+  background: var(--color-green);
 }

--- a/src/utils/flexbox.css
+++ b/src/utils/flexbox.css
@@ -1,19 +1,19 @@
-.u-flex--1 {
+.u-flex-1 {
   flex: 1;
 }
 
-.u-flex--2 {
+.u-flex-2 {
   flex: 2;
 }
 
-.u-flex--3 {
+.u-flex-3 {
   flex: 3;
 }
 
-.u-flex--4 {
+.u-flex-4 {
   flex: 4;
 }
 
-.u-flex--5 {
+.u-flex-5 {
   flex: 5;
 }

--- a/src/utils/layout.css
+++ b/src/utils/layout.css
@@ -1,81 +1,75 @@
-.u-align-content {
-  &--start {
-    align-content: start;
-  }
-
-  &--end {
-    align-content: end;
-  }
-
-  &--center {
-    align-content: center;
-  }
-
-  &--stretch {
-    align-content: stretch;
-  }
-
-  &--space-around {
-    align-content: space-around;
-  }
-
-  &--space-between {
-    align-content: space-between;
-  }
-
-  &--space-evenly {
-    align-content: space-evenly;
-  }
+.u-align-content-start {
+  align-content: start;
 }
 
-.u-justify-content {
-  &--start {
-    justify-content: start;
-  }
-
-  &--end {
-    justify-content: end;
-  }
-
-  &--center {
-    justify-content: center;
-  }
-
-  &--stretch {
-    justify-content: stretch;
-  }
-
-  &--space-around {
-    justify-content: space-around;
-  }
-
-  &--space-between {
-    justify-content: space-between;
-  }
-
-  &--space-evenly {
-    align-content: space-evenly;
-  }
+.u-align-content-end {
+  align-content: end;
 }
 
-.u-align-items {
-  &--start {
-    align-items: start;
-  }
+.u-align-content-center {
+  align-content: center;
+}
 
-  &--end {
-    align-items: end;
-  }
+.u-align-content-stretch {
+  align-content: stretch;
+}
 
-  &--center {
-    align-items: center;
-  }
+.u-align-content-space-around {
+  align-content: space-around;
+}
 
-  &--baseline {
-    align-items: baseline;
-  }
+.u-align-content-space-between {
+  align-content: space-between;
+}
 
-  &--stretch {
-    align-items: stretch;
-  }
+.u-align-content-space-evenly {
+  align-content: space-evenly;
+}
+
+.u-justify-content-start {
+  justify-content: start;
+}
+
+.u-justify-content-end {
+  justify-content: end;
+}
+
+.u-justify-content-center {
+  justify-content: center;
+}
+
+.u-justify-content-stretch {
+  justify-content: stretch;
+}
+
+.u-justify-content-space-around {
+  justify-content: space-around;
+}
+
+.u-justify-content-space-between {
+  justify-content: space-between;
+}
+
+.u-justify-content-space-evenly {
+  align-content: space-evenly;
+}
+
+.u-align-items-start {
+  align-items: start;
+}
+
+.u-align-items-end {
+  align-items: end;
+}
+
+.u-align-items-center {
+  align-items: center;
+}
+
+.u-align-items-baseline {
+  align-items: baseline;
+}
+
+.u-align-items-stretch {
+  align-items: stretch;
 }

--- a/src/utils/spacing/margin.css
+++ b/src/utils/spacing/margin.css
@@ -1,306 +1,306 @@
-.u-m--auto {
+.u-m-auto {
   margin: auto;
 }
 
-.u-m--xxsm {
+.u-m-xxsm {
   margin: var(--spacing-xx-small);
 }
 
-.u-m--xsm {
+.u-m-xsm {
   margin: var(--spacing-x-small);
 }
 
-.u-m--sm {
+.u-m-sm {
   margin: var(--spacing-small);
 }
 
 .u-m,
-.u-m--base {
+.u-m-base {
   margin: var(--spacing-normal);
 }
 
-.u-m--md {
+.u-m-md {
   margin: var(--spacing-medium);
 }
 
-.u-m--lg {
+.u-m-lg {
   margin: var(--spacing-large);
 }
 
-.u-m--xlg {
+.u-m-xlg {
   margin: var(--spacing-x-large);
 }
 
-.u-m--xxlg {
+.u-m-xxlg {
   margin: var(--spacing-xx-large);
 }
 
-.u-m--xxxlg {
+.u-m-xxxlg {
   margin: var(--spacing-xxx-large);
 }
 
-.u-my--auto {
+.u-my-auto {
   margin-top: auto;
   margin-bottom: auto;
 }
 
-.u-mx--auto {
+.u-mx-auto {
   margin-right: auto;
   margin-left: auto;
 }
 
-.u-my--xxsm {
+.u-my-xxsm {
   margin-top: var(--spacing-xx-small);
   margin-bottom: var(--spacing-xx-small);
 }
 
-.u-mx--xxsm {
+.u-mx-xxsm {
   margin-right: var(--spacing-xx-small);
   margin-left: var(--spacing-xx-small);
 }
 
-.u-my--xsm {
+.u-my-xsm {
   margin-top: var(--spacing-x-small);
   margin-bottom: var(--spacing-x-small);
 }
 
-.u-mx--xsm {
+.u-mx-xsm {
   margin-right: var(--spacing-x-small);
   margin-left: var(--spacing-x-small);
 }
 
-.u-my--sm {
+.u-my-sm {
   margin-top: var(--spacing-small);
   margin-bottom: var(--spacing-small);
 }
 
-.u-mx--sm {
+.u-mx-sm {
   margin-right: var(--spacing-small);
   margin-left: var(--spacing-small);
 }
 
 .u-my,
-.u-my--base {
+.u-my-base {
   margin-top: var(--spacing-normal);
   margin-bottom: var(--spacing-normal);
 }
 
 .u-mx,
-.u-mx--base {
+.u-mx-base {
   margin-right: var(--spacing-normal);
   margin-left: var(--spacing-normal);
 }
 
-.u-my--md {
+.u-my-md {
   margin-top: var(--spacing-medium);
   margin-bottom: var(--spacing-medium);
 }
 
-.u-mx--md {
+.u-mx-md {
   margin-right: var(--spacing-medium);
   margin-left: var(--spacing-medium);
 }
 
-.u-my--lg {
+.u-my-lg {
   margin-top: var(--spacing-large);
   margin-bottom: var(--spacing-large);
 }
 
-.u-mx--lg {
+.u-mx-lg {
   margin-right: var(--spacing-large);
   margin-left: var(--spacing-large);
 }
 
-.u-my--xlg {
+.u-my-xlg {
   margin-top: var(--spacing-x-large);
   margin-bottom: var(--spacing-x-large);
 }
 
-.u-mx--xlg {
+.u-mx-xlg {
   margin-right: var(--spacing-x-large);
   margin-left: var(--spacing-x-large);
 }
 
-.u-my--xxlg {
+.u-my-xxlg {
   margin-top: var(--spacing-xx-large);
   margin-bottom: var(--spacing-xx-large);
 }
 
-.u-mx--xxlg {
+.u-mx-xxlg {
   margin-right: var(--spacing-xx-large);
   margin-left: var(--spacing-xx-large);
 }
 
-.u-my--xxxlg {
+.u-my-xxxlg {
   margin-top: var(--spacing-xxx-large);
   margin-bottom: var(--spacing-xxx-large);
 }
 
-.u-mx--xxxlg {
+.u-mx-xxxlg {
   margin-right: var(--spacing-xxx-large);
   margin-left: var(--spacing-xxx-large);
 }
 
-.u-mt--auto {
+.u-mt-auto {
   margin-top: auto;
 }
 
-.u-mr--auto {
+.u-mr-auto {
   margin-right: auto;
 }
 
-.u-mb--auto {
+.u-mb-auto {
   margin-bottom: auto;
 }
 
-.u-ml--auto {
+.u-ml-auto {
   margin-left: auto;
 }
 
-.u-mt--xxsm {
+.u-mt-xxsm {
   margin-top: var(--spacing-xx-small);
 }
 
-.u-mr--xxsm {
+.u-mr-xxsm {
   margin-right: var(--spacing-xx-small);
 }
 
-.u-mb--xxsm {
+.u-mb-xxsm {
   margin-bottom: var(--spacing-xx-small);
 }
 
-.u-ml--xxsm {
+.u-ml-xxsm {
   margin-left: var(--spacing-xx-small);
 }
 
-.u-mt--xsm {
+.u-mt-xsm {
   margin-top: var(--spacing-x-small);
 }
 
-.u-mr--xsm {
+.u-mr-xsm {
   margin-right: var(--spacing-x-small);
 }
 
-.u-mb--xsm {
+.u-mb-xsm {
   margin-bottom: var(--spacing-x-small);
 }
 
-.u-ml--xsm {
+.u-ml-xsm {
   margin-left: var(--spacing-x-small);
 }
 
-.u-mt--sm {
+.u-mt-sm {
   margin-top: var(--spacing-small);
 }
 
-.u-mr--sm {
+.u-mr-sm {
   margin-right: var(--spacing-small);
 }
 
-.u-mb--sm {
+.u-mb-sm {
   margin-bottom: var(--spacing-small);
 }
 
-.u-ml--sm {
+.u-ml-sm {
   margin-left: var(--spacing-small);
 }
 
 .u-mt,
-.u-mt--base {
+.u-mt-base {
   margin-top: var(--spacing-normal);
 }
 
 .u-mr,
-.u-mr--base {
+.u-mr-base {
   margin-right: var(--spacing-normal);
 }
 
 .u-mb,
-.u-mb--base {
+.u-mb-base {
   margin-bottom: var(--spacing-normal);
 }
 
 .u-ml,
-.u-ml--base {
+.u-ml-base {
   margin-left: var(--spacing-normal);
 }
 
-.u-mt--md {
+.u-mt-md {
   margin-top: var(--spacing-medium);
 }
 
-.u-mr--md {
+.u-mr-md {
   margin-right: var(--spacing-medium);
 }
 
-.u-mb--md {
+.u-mb-md {
   margin-bottom: var(--spacing-medium);
 }
 
-.u-ml--md {
+.u-ml-md {
   margin-left: var(--spacing-medium);
 }
 
-.u-mt--lg {
+.u-mt-lg {
   margin-top: var(--spacing-large);
 }
 
-.u-mr--lg {
+.u-mr-lg {
   margin-right: var(--spacing-large);
 }
 
-.u-mb--lg {
+.u-mb-lg {
   margin-bottom: var(--spacing-large);
 }
 
-.u-ml--lg {
+.u-ml-lg {
   margin-left: var(--spacing-large);
 }
 
-.u-mt--xlg {
+.u-mt-xlg {
   margin-top: var(--spacing-x-large);
 }
 
-.u-mr--xlg {
+.u-mr-xlg {
   margin-right: var(--spacing-x-large);
 }
 
-.u-mb--xlg {
+.u-mb-xlg {
   margin-bottom: var(--spacing-x-large);
 }
 
-.u-ml--xlg {
+.u-ml-xlg {
   margin-left: var(--spacing-x-large);
 }
 
-.u-mt--xxlg {
+.u-mt-xxlg {
   margin-top: var(--spacing-xx-large);
 }
 
-.u-mr--xxlg {
+.u-mr-xxlg {
   margin-right: var(--spacing-xx-large);
 }
 
-.u-mb--xxlg {
+.u-mb-xxlg {
   margin-bottom: var(--spacing-xx-large);
 }
 
-.u-ml--xxlg {
+.u-ml-xxlg {
   margin-left: var(--spacing-xx-large);
 }
 
-.u-mt--xxxlg {
+.u-mt-xxxlg {
   margin-top: var(--spacing-xxx-large);
 }
 
-.u-mr--xxxlg {
+.u-mr-xxxlg {
   margin-right: var(--spacing-xxx-large);
 }
 
-.u-mb--xxxlg {
+.u-mb-xxxlg {
   margin-bottom: var(--spacing-xxx-large);
 }
 
-.u-ml--xxxlg {
+.u-ml-xxxlg {
   margin-left: var(--spacing-xxx-large);
 }

--- a/src/utils/text/align.css
+++ b/src/utils/text/align.css
@@ -1,17 +1,15 @@
-.u-t {
-  &--left {
-    text-align: left;
-  }
+.u-t-left {
+  text-align: left;
+}
 
-  &--center {
-    text-align: center;
-  }
+.u-t-center {
+  text-align: center;
+}
 
-  &--right {
-    text-align: right;
-  }
+.u-t-right {
+  text-align: right;
+}
 
-  &--justify {
-    text-align: justify;
-  }
+.u-t-justify {
+  text-align: justify;
 }

--- a/src/utils/text/color.css
+++ b/src/utils/text/color.css
@@ -1,73 +1,71 @@
-.u-t {
-  &--white {
-    color: var(--color-white);
-  }
+.u-t-white {
+  color: var(--color-white);
+}
 
-  &--grey-light {
-    color: var(--color-grey-light);
-  }
+.u-t-grey-light {
+  color: var(--color-grey-light);
+}
 
-  &--grey {
-    color: var(--color-grey);
-  }
+.u-t-grey {
+  color: var(--color-grey);
+}
 
-  &--grey-dark {
-    color: var(--color-grey-dark);
-  }
+.u-t-grey-dark {
+  color: var(--color-grey-dark);
+}
 
-  &--grey-darkest {
-    color: var(--color-grey-darkest);
-  }
+.u-t-grey-darkest {
+  color: var(--color-grey-darkest);
+}
 
-  &--green-light {
-    color: var(--color-green-light);
-  }
+.u-t-green-light {
+  color: var(--color-green-light);
+}
 
-  &--green-medium {
-    color: var(--color-green-medium);
-  }
+.u-t-green-medium {
+  color: var(--color-green-medium);
+}
 
-  &--green {
-    color: var(--color-green);
-  }
+.u-t-green {
+  color: var(--color-green);
+}
 
-  &--green-dark {
-    color: var(--color-green-dark);
-  }
+.u-t-green-dark {
+  color: var(--color-green-dark);
+}
 
-  &--pink {
-    color: var(--color-pink);
-  }
+.u-t-pink {
+  color: var(--color-pink);
+}
 
-  &--red {
-    color: var(--color-red);
-  }
+.u-t-red {
+  color: var(--color-red);
+}
 
-  &--orange {
-    color: var(--color-orange);
-  }
+.u-t-orange {
+  color: var(--color-orange);
+}
 
-  &--purple {
-    color: var(--color-purple);
-  }
+.u-t-purple {
+  color: var(--color-purple);
+}
 
-  &--blue {
-    color: var(--color-blue);
-  }
+.u-t-blue {
+  color: var(--color-blue);
+}
 
-  &--cyan {
-    color: var(--color-cyan);
-  }
+.u-t-cyan {
+  color: var(--color-cyan);
+}
 
-  &--brown {
-    color: var(--color-brown);
-  }
+.u-t-brown {
+  color: var(--color-brown);
+}
 
-  &--yellow {
-    color: var(--color-yellow);
-  }
+.u-t-yellow {
+  color: var(--color-yellow);
+}
 
-  &--primary {
-    color: var(--color-green);
-  }
+.u-t-primary {
+  color: var(--color-green);
 }

--- a/src/utils/text/decoration.css
+++ b/src/utils/text/decoration.css
@@ -1,9 +1,7 @@
-.u-t {
-  &--line-through {
-    text-decoration: line-through;
-  }
+.u-t-line-through {
+  text-decoration: line-through;
+}
 
-  &--underline {
-    text-decoration: underline;
-  }
+.u-t-underline {
+  text-decoration: underline;
 }

--- a/src/utils/text/misc.css
+++ b/src/utils/text/misc.css
@@ -1,17 +1,15 @@
-.u-t {
-  &--sub {
-    position: relative;
-    bottom: -0.25em;
-    font-size: 75%;
-    line-height: 0;
-    vertical-align: baseline;
-  }
+.u-t-sub {
+  position: relative;
+  bottom: -0.25em;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
 
-  &--sup {
-    position: relative;
-    top: -0.5em;
-    font-size: 75%;
-    line-height: 0;
-    vertical-align: baseline;
-  }
+.u-t-sup {
+  position: relative;
+  top: -0.5em;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
 }

--- a/src/utils/text/size.css
+++ b/src/utils/text/size.css
@@ -1,33 +1,31 @@
-.u-t {
-  &--xs {
-    font-size: var(--font-size-tiny);
-  }
+.u-t-xs {
+  font-size: var(--font-size-tiny);
+}
 
-  &--sm {
-    font-size: var(--font-size-small);
-  }
+.u-t-sm {
+  font-size: var(--font-size-small);
+}
 
-  &--base {
-    font-size: var(--font-size-normal);
-  }
+.u-t-base {
+  font-size: var(--font-size-normal);
+}
 
-  &--md {
-    font-size: var(--font-size-medium);
-  }
+.u-t-md {
+  font-size: var(--font-size-medium);
+}
 
-  &--lg {
-    font-size: var(--font-size-large);
-  }
+.u-t-lg {
+  font-size: var(--font-size-large);
+}
 
-  &--xlg {
-    font-size: var(--font-size-x-large);
-  }
+.u-t-xlg {
+  font-size: var(--font-size-x-large);
+}
 
-  &--xxlg {
-    font-size: var(--font-size-xx-large);
-  }
+.u-t-xxlg {
+  font-size: var(--font-size-xx-large);
+}
 
-  &--xxxlg {
-    font-size: var(--font-size-xxx-large);
-  }
+.u-t-xxxlg {
+  font-size: var(--font-size-xxx-large);
 }

--- a/src/utils/text/style.css
+++ b/src/utils/text/style.css
@@ -1,9 +1,7 @@
-.u-t {
-  &--italic {
-    font-style: italic;
-  }
+.u-t-italic {
+  font-style: italic;
+}
 
-  &--non-italic {
-    font-style: normal;
-  }
+.u-t-non-italic {
+  font-style: normal;
 }

--- a/src/utils/text/transform.css
+++ b/src/utils/text/transform.css
@@ -1,13 +1,11 @@
-.u-t {
-  &--lowercase {
-    text-transform: lowercase;
-  }
+.u-t-lowercase {
+  text-transform: lowercase;
+}
 
-  &--uppercase {
-    text-transform: uppercase;
-  }
+.u-t-uppercase {
+  text-transform: uppercase;
+}
 
-  &--capitalize {
-    text-transform: capitalize;
-  }
+.u-t-capitalize {
+  text-transform: capitalize;
 }

--- a/src/utils/text/weight.css
+++ b/src/utils/text/weight.css
@@ -1,5 +1,3 @@
-.u-t {
-  &--bold {
-    font-weight: 700;
-  }
+.u-t-bold {
+  font-weight: 700;
 }


### PR DESCRIPTION
It doesn't make sense to give utilities a modifier since there is
nothing to modify.

To give an example:

When you have a `.c-box`, you can have a modifier of `--with-spacing` to
indicate that there is a variation on the `c-box` that has extra
spacing.

In the case of utilities this doesn't work, when you take the `.u-t`
class for example, there is no base for that, only the actual utilities
like `u-t-underline`.

To make this more clear we are removing the `--` from the utility
classes.

Keep in mind that we are keeping the BEM style modifiers for all the
other css that we create, just not for utilitlies