### PR TITLE
Use a spacing scale that is a factor of 0.25

### DIFF
--- a/src/components/box.css
+++ b/src/components/box.css
@@ -5,6 +5,6 @@
   border-radius: var(--border-radius);
 
   &--with-spacing {
-    padding: var(--spacing-normal);
+    padding: var(--spacing-6);
   }
 }

--- a/src/components/navigation.css
+++ b/src/components/navigation.css
@@ -4,7 +4,7 @@
   list-style: none;
 
   &__item {
-    margin-right: var(--spacing-medium);
+    margin-right: var(--spacing-8);
   }
 
   &__link {

--- a/src/components/topbar.css
+++ b/src/components/topbar.css
@@ -3,7 +3,7 @@
   border-bottom: 1px solid var(--color-grey);
 
   &__logo {
-    @extend .u-mr-lg;
+    @extend .u-mr-9;
   }
 
   &__login {

--- a/src/elements/typography.css
+++ b/src/elements/typography.css
@@ -13,7 +13,7 @@ blockquote,
 ol,
 p,
 ul {
-  margin: 0 0 var(--spacing-normal);
+  margin: 0 0 var(--spacing-6);
   opacity: 0.8;
 }
 

--- a/src/generated/index.custom-properties.css
+++ b/src/generated/index.custom-properties.css
@@ -58,24 +58,19 @@
   --spacing-grid-margin: 2.25rem;
   /* Grid column size */
   --spacing-grid-column: 45rem;
-  /* For micro adjustments */
-  --spacing-xx-small: 0.444rem;
-  /* For micro adjustments */
-  --spacing-x-small: 0.667rem;
-  /* For paddings in labels / inline stuff */
-  --spacing-small: 1rem;
-  /* Regular padding for compact tables and such. */
-  --spacing-normal: 1.5rem;
-  /* For paddings in labels / inline stuff */
-  --spacing-medium: 2.25rem;
-  /* Padding for the inside of boxes */
-  --spacing-large: 3.375rem;
-  /* Padding between elements and for boxes with larger font-sizes */
-  --spacing-x-large: 5.0625rem;
-  /* Larger padding for when bigger spacing is needed */
-  --spacing-xx-large: 7.6rem;
-  /* Huge padding we can use for seperation of vertical sections */
-  --spacing-xxx-large: 11.4rem;
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.25rem;
+  --spacing-6: 1.5rem;
+  --spacing-7: 2rem;
+  --spacing-8: 2.25rem;
+  --spacing-9: 3rem;
+  --spacing-10: 4rem;
+  --spacing-11: 5rem;
+  --spacing-12: 8rem;
+  --spacing-13: 12rem;
   /* Small breakpoint */
   --break-small: 25rem;
   /* Small breakpoint */

--- a/src/utils/spacing/margin.css
+++ b/src/utils/spacing/margin.css
@@ -1,42 +1,243 @@
+.u-m-1 {
+  margin: var(--spacing-1);
+}
+
+.u-m-2 {
+  margin: var(--spacing-2);
+}
+
+.u-m,
+.u-m-3 {
+  margin: var(--spacing-3);
+}
+
+.u-m-4 {
+  margin: var(--spacing-4);
+}
+
+.u-m-5 {
+  margin: var(--spacing-5);
+}
+
+.u-m-6 {
+  margin: var(--spacing-6);
+}
+
+.u-m-7 {
+  margin: var(--spacing-7);
+}
+
+.u-m-8 {
+  margin: var(--spacing-8);
+}
+
+.u-m-9 {
+  margin: var(--spacing-9);
+}
+
+.u-m-10 {
+  margin: var(--spacing-10);
+}
+
+.u-m-11 {
+  margin: var(--spacing-11);
+}
+
+.u-m-12 {
+  margin: var(--spacing-12);
+}
+
+.u-m-13 {
+  margin: var(--spacing-13);
+}
+
 .u-m-auto {
   margin: auto;
 }
 
-.u-m-xxsm {
-  margin: var(--spacing-xx-small);
+.u-nm-1 {
+  margin: calc(var(--spacing-1) * -1);
 }
 
-.u-m-xsm {
-  margin: var(--spacing-x-small);
+.u-nm-2 {
+  margin: calc(var(--spacing-2) * -1);
 }
 
-.u-m-sm {
-  margin: var(--spacing-small);
+.u-nm,
+.u-nm-3 {
+  margin: calc(var(--spacing-3) * -1);
 }
 
-.u-m,
-.u-m-base {
-  margin: var(--spacing-normal);
+.u-nm-4 {
+  margin: calc(var(--spacing-4) * -1);
 }
 
-.u-m-md {
-  margin: var(--spacing-medium);
+.u-nm-5 {
+  margin: calc(var(--spacing-5) * -1);
 }
 
-.u-m-lg {
-  margin: var(--spacing-large);
+.u-nm-6 {
+  margin: calc(var(--spacing-6) * -1);
 }
 
-.u-m-xlg {
-  margin: var(--spacing-x-large);
+.u-nm-7 {
+  margin: calc(var(--spacing-7) * -1);
 }
 
-.u-m-xxlg {
-  margin: var(--spacing-xx-large);
+.u-nm-8 {
+  margin: calc(var(--spacing-8) * -1);
 }
 
-.u-m-xxxlg {
-  margin: var(--spacing-xxx-large);
+.u-nm-9 {
+  margin: calc(var(--spacing-9) * -1);
+}
+
+.u-nm-10 {
+  margin: calc(var(--spacing-10) * -1);
+}
+
+.u-nm-11 {
+  margin: calc(var(--spacing-11) * -1);
+}
+
+.u-nm-12 {
+  margin: calc(var(--spacing-12) * -1);
+}
+
+.u-nm-13 {
+  margin: calc(var(--spacing-13) * -1);
+}
+
+.u-my-1 {
+  margin-top: var(--spacing-1);
+  margin-bottom: var(--spacing-1);
+}
+
+.u-mx-1 {
+  margin-right: var(--spacing-1);
+  margin-left: var(--spacing-1);
+}
+
+.u-my-2 {
+  margin-top: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
+}
+
+.u-mx-2 {
+  margin-right: var(--spacing-2);
+  margin-left: var(--spacing-2);
+}
+
+.u-my,
+.u-my-3 {
+  margin-top: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.u-mx,
+.u-mx-3 {
+  margin-right: var(--spacing-3);
+  margin-left: var(--spacing-3);
+}
+
+.u-my-4 {
+  margin-top: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+.u-mx-4 {
+  margin-right: var(--spacing-4);
+  margin-left: var(--spacing-4);
+}
+
+.u-my-5 {
+  margin-top: var(--spacing-5);
+  margin-bottom: var(--spacing-5);
+}
+
+.u-mx-5 {
+  margin-right: var(--spacing-5);
+  margin-left: var(--spacing-5);
+}
+
+.u-my-6 {
+  margin-top: var(--spacing-6);
+  margin-bottom: var(--spacing-6);
+}
+
+.u-mx-6 {
+  margin-right: var(--spacing-6);
+  margin-left: var(--spacing-6);
+}
+
+.u-my-7 {
+  margin-top: var(--spacing-7);
+  margin-bottom: var(--spacing-7);
+}
+
+.u-mx-7 {
+  margin-right: var(--spacing-7);
+  margin-left: var(--spacing-7);
+}
+
+.u-my-8 {
+  margin-top: var(--spacing-8);
+  margin-bottom: var(--spacing-8);
+}
+
+.u-mx-8 {
+  margin-right: var(--spacing-8);
+  margin-left: var(--spacing-8);
+}
+
+.u-my-9 {
+  margin-top: var(--spacing-9);
+  margin-bottom: var(--spacing-9);
+}
+
+.u-mx-9 {
+  margin-right: var(--spacing-9);
+  margin-left: var(--spacing-9);
+}
+
+.u-my-10 {
+  margin-top: var(--spacing-10);
+  margin-bottom: var(--spacing-10);
+}
+
+.u-mx-10 {
+  margin-right: var(--spacing-10);
+  margin-left: var(--spacing-10);
+}
+
+.u-my-11 {
+  margin-top: var(--spacing-11);
+  margin-bottom: var(--spacing-11);
+}
+
+.u-mx-11 {
+  margin-right: var(--spacing-11);
+  margin-left: var(--spacing-11);
+}
+
+.u-my-12 {
+  margin-top: var(--spacing-12);
+  margin-bottom: var(--spacing-12);
+}
+
+.u-mx-12 {
+  margin-right: var(--spacing-12);
+  margin-left: var(--spacing-12);
+}
+
+.u-my-13 {
+  margin-top: var(--spacing-13);
+  margin-bottom: var(--spacing-13);
+}
+
+.u-mx-13 {
+  margin-right: var(--spacing-13);
+  margin-left: var(--spacing-13);
 }
 
 .u-my-auto {
@@ -49,96 +250,348 @@
   margin-left: auto;
 }
 
-.u-my-xxsm {
-  margin-top: var(--spacing-xx-small);
-  margin-bottom: var(--spacing-xx-small);
+.u-nmy-1 {
+  margin-top: calc(var(--spacing-1) * -1);
+  margin-bottom: calc(var(--spacing-1) * -1);
 }
 
-.u-mx-xxsm {
-  margin-right: var(--spacing-xx-small);
-  margin-left: var(--spacing-xx-small);
+.u-nmx-1 {
+  margin-right: calc(var(--spacing-1) * -1);
+  margin-left: calc(var(--spacing-1) * -1);
 }
 
-.u-my-xsm {
-  margin-top: var(--spacing-x-small);
-  margin-bottom: var(--spacing-x-small);
+.u-nmy-2 {
+  margin-top: calc(var(--spacing-2) * -1);
+  margin-bottom: calc(var(--spacing-2) * -1);
 }
 
-.u-mx-xsm {
-  margin-right: var(--spacing-x-small);
-  margin-left: var(--spacing-x-small);
+.u-nmx-2 {
+  margin-right: calc(var(--spacing-2) * -1);
+  margin-left: calc(var(--spacing-2) * -1);
 }
 
-.u-my-sm {
-  margin-top: var(--spacing-small);
-  margin-bottom: var(--spacing-small);
+.u-nmy,
+.u-nmy-3 {
+  margin-top: calc(var(--spacing-3) * -1);
+  margin-bottom: calc(var(--spacing-3) * -1);
 }
 
-.u-mx-sm {
-  margin-right: var(--spacing-small);
-  margin-left: var(--spacing-small);
+.u-nmx,
+.u-nmx-3 {
+  margin-right: calc(var(--spacing-3) * -1);
+  margin-left: calc(var(--spacing-3) * -1);
 }
 
-.u-my,
-.u-my-base {
-  margin-top: var(--spacing-normal);
-  margin-bottom: var(--spacing-normal);
+.u-nmy-4 {
+  margin-top: calc(var(--spacing-4) * -1);
+  margin-bottom: calc(var(--spacing-4) * -1);
 }
 
-.u-mx,
-.u-mx-base {
-  margin-right: var(--spacing-normal);
-  margin-left: var(--spacing-normal);
+.u-nmx-4 {
+  margin-right: calc(var(--spacing-4) * -1);
+  margin-left: calc(var(--spacing-4) * -1);
 }
 
-.u-my-md {
-  margin-top: var(--spacing-medium);
-  margin-bottom: var(--spacing-medium);
+.u-nmy-5 {
+  margin-top: calc(var(--spacing-5) * -1);
+  margin-bottom: calc(var(--spacing-5) * -1);
 }
 
-.u-mx-md {
-  margin-right: var(--spacing-medium);
-  margin-left: var(--spacing-medium);
+.u-nmx-5 {
+  margin-right: calc(var(--spacing-5) * -1);
+  margin-left: calc(var(--spacing-5) * -1);
 }
 
-.u-my-lg {
-  margin-top: var(--spacing-large);
-  margin-bottom: var(--spacing-large);
+.u-nmy-6 {
+  margin-top: calc(var(--spacing-6) * -1);
+  margin-bottom: calc(var(--spacing-6) * -1);
 }
 
-.u-mx-lg {
-  margin-right: var(--spacing-large);
-  margin-left: var(--spacing-large);
+.u-nmx-6 {
+  margin-right: calc(var(--spacing-6) * -1);
+  margin-left: calc(var(--spacing-6) * -1);
 }
 
-.u-my-xlg {
-  margin-top: var(--spacing-x-large);
-  margin-bottom: var(--spacing-x-large);
+.u-nmy-7 {
+  margin-top: calc(var(--spacing-7) * -1);
+  margin-bottom: calc(var(--spacing-7) * -1);
 }
 
-.u-mx-xlg {
-  margin-right: var(--spacing-x-large);
-  margin-left: var(--spacing-x-large);
+.u-nmx-7 {
+  margin-right: calc(var(--spacing-7) * -1);
+  margin-left: calc(var(--spacing-7) * -1);
 }
 
-.u-my-xxlg {
-  margin-top: var(--spacing-xx-large);
-  margin-bottom: var(--spacing-xx-large);
+.u-nmy-8 {
+  margin-top: calc(var(--spacing-8) * -1);
+  margin-bottom: calc(var(--spacing-8) * -1);
 }
 
-.u-mx-xxlg {
-  margin-right: var(--spacing-xx-large);
-  margin-left: var(--spacing-xx-large);
+.u-nmx-8 {
+  margin-right: calc(var(--spacing-8) * -1);
+  margin-left: calc(var(--spacing-8) * -1);
 }
 
-.u-my-xxxlg {
-  margin-top: var(--spacing-xxx-large);
-  margin-bottom: var(--spacing-xxx-large);
+.u-nmy-9 {
+  margin-top: calc(var(--spacing-9) * -1);
+  margin-bottom: calc(var(--spacing-9) * -1);
 }
 
-.u-mx-xxxlg {
-  margin-right: var(--spacing-xxx-large);
-  margin-left: var(--spacing-xxx-large);
+.u-nmx-9 {
+  margin-right: calc(var(--spacing-9) * -1);
+  margin-left: calc(var(--spacing-9) * -1);
+}
+
+.u-nmy-10 {
+  margin-top: calc(var(--spacing-10) * -1);
+  margin-bottom: calc(var(--spacing-10) * -1);
+}
+
+.u-nmx-10 {
+  margin-right: calc(var(--spacing-10) * -1);
+  margin-left: calc(var(--spacing-10) * -1);
+}
+
+.u-nmy-11 {
+  margin-top: calc(var(--spacing-11) * -1);
+  margin-bottom: calc(var(--spacing-11) * -1);
+}
+
+.u-nmx-11 {
+  margin-right: calc(var(--spacing-11) * -1);
+  margin-left: calc(var(--spacing-11) * -1);
+}
+
+.u-nmy-12 {
+  margin-top: calc(var(--spacing-12) * -1);
+  margin-bottom: calc(var(--spacing-12) * -1);
+}
+
+.u-nmx-12 {
+  margin-right: calc(var(--spacing-12) * -1);
+  margin-left: calc(var(--spacing-12) * -1);
+}
+
+.u-nmy-13 {
+  margin-top: calc(var(--spacing-13) * -1);
+  margin-bottom: calc(var(--spacing-13) * -1);
+}
+
+.u-nmx-13 {
+  margin-right: calc(var(--spacing-13) * -1);
+  margin-left: calc(var(--spacing-13) * -1);
+}
+
+.u-mt-1 {
+  margin-top: var(--spacing-1);
+}
+
+.u-mr-1 {
+  margin-right: var(--spacing-1);
+}
+
+.u-mb-1 {
+  margin-bottom: var(--spacing-1);
+}
+
+.u-ml-1 {
+  margin-left: var(--spacing-1);
+}
+
+.u-mt-2 {
+  margin-top: var(--spacing-2);
+}
+
+.u-mr-2 {
+  margin-right: var(--spacing-2);
+}
+
+.u-mb-2 {
+  margin-bottom: var(--spacing-2);
+}
+
+.u-ml-2 {
+  margin-left: var(--spacing-2);
+}
+
+.u-mt,
+.u-mt-3 {
+  margin-top: var(--spacing-3);
+}
+
+.u-mr,
+.u-mr-3 {
+  margin-right: var(--spacing-3);
+}
+
+.u-mb,
+.u-mb-3 {
+  margin-bottom: var(--spacing-3);
+}
+
+.u-ml,
+.u-ml-3 {
+  margin-left: var(--spacing-3);
+}
+
+.u-mt-4 {
+  margin-top: var(--spacing-4);
+}
+
+.u-mr-4 {
+  margin-right: var(--spacing-4);
+}
+
+.u-mb-4 {
+  margin-bottom: var(--spacing-4);
+}
+
+.u-ml-4 {
+  margin-left: var(--spacing-4);
+}
+
+.u-mt-5 {
+  margin-top: var(--spacing-5);
+}
+
+.u-mr-5 {
+  margin-right: var(--spacing-5);
+}
+
+.u-mb-5 {
+  margin-bottom: var(--spacing-5);
+}
+
+.u-ml-5 {
+  margin-left: var(--spacing-5);
+}
+
+.u-mt-6 {
+  margin-top: var(--spacing-6);
+}
+
+.u-mr-6 {
+  margin-right: var(--spacing-6);
+}
+
+.u-mb-6 {
+  margin-bottom: var(--spacing-6);
+}
+
+.u-ml-6 {
+  margin-left: var(--spacing-6);
+}
+
+.u-mt-7 {
+  margin-top: var(--spacing-7);
+}
+
+.u-mr-7 {
+  margin-right: var(--spacing-7);
+}
+
+.u-mb-7 {
+  margin-bottom: var(--spacing-7);
+}
+
+.u-ml-7 {
+  margin-left: var(--spacing-7);
+}
+
+.u-mt-8 {
+  margin-top: var(--spacing-8);
+}
+
+.u-mr-8 {
+  margin-right: var(--spacing-8);
+}
+
+.u-mb-8 {
+  margin-bottom: var(--spacing-8);
+}
+
+.u-ml-8 {
+  margin-left: var(--spacing-8);
+}
+
+.u-mt-9 {
+  margin-top: var(--spacing-9);
+}
+
+.u-mr-9 {
+  margin-right: var(--spacing-9);
+}
+
+.u-mb-9 {
+  margin-bottom: var(--spacing-9);
+}
+
+.u-ml-9 {
+  margin-left: var(--spacing-9);
+}
+
+.u-mt-10 {
+  margin-top: var(--spacing-10);
+}
+
+.u-mr-10 {
+  margin-right: var(--spacing-10);
+}
+
+.u-mb-10 {
+  margin-bottom: var(--spacing-10);
+}
+
+.u-ml-10 {
+  margin-left: var(--spacing-10);
+}
+
+.u-mt-11 {
+  margin-top: var(--spacing-11);
+}
+
+.u-mr-11 {
+  margin-right: var(--spacing-11);
+}
+
+.u-mb-11 {
+  margin-bottom: var(--spacing-11);
+}
+
+.u-ml-11 {
+  margin-left: var(--spacing-11);
+}
+
+.u-mt-12 {
+  margin-top: var(--spacing-12);
+}
+
+.u-mr-12 {
+  margin-right: var(--spacing-12);
+}
+
+.u-mb-12 {
+  margin-bottom: var(--spacing-12);
+}
+
+.u-ml-12 {
+  margin-left: var(--spacing-12);
+}
+
+.u-mt-13 {
+  margin-top: var(--spacing-13);
+}
+
+.u-mr-13 {
+  margin-right: var(--spacing-13);
+}
+
+.u-mb-13 {
+  margin-bottom: var(--spacing-13);
+}
+
+.u-ml-13 {
+  margin-left: var(--spacing-13);
 }
 
 .u-mt-auto {
@@ -157,150 +610,214 @@
   margin-left: auto;
 }
 
-.u-mt-xxsm {
-  margin-top: var(--spacing-xx-small);
+.u-nmt-1 {
+  margin-top: calc(var(--spacing-1) * -1);
 }
 
-.u-mr-xxsm {
-  margin-right: var(--spacing-xx-small);
+.u-nmr-1 {
+  margin-right: calc(var(--spacing-1) * -1);
 }
 
-.u-mb-xxsm {
-  margin-bottom: var(--spacing-xx-small);
+.u-nmb-1 {
+  margin-bottom: calc(var(--spacing-1) * -1);
 }
 
-.u-ml-xxsm {
-  margin-left: var(--spacing-xx-small);
+.u-nml-1 {
+  margin-left: calc(var(--spacing-1) * -1);
 }
 
-.u-mt-xsm {
-  margin-top: var(--spacing-x-small);
+.u-nmt-2 {
+  margin-top: calc(var(--spacing-2) * -1);
 }
 
-.u-mr-xsm {
-  margin-right: var(--spacing-x-small);
+.u-nmr-2 {
+  margin-right: calc(var(--spacing-2) * -1);
 }
 
-.u-mb-xsm {
-  margin-bottom: var(--spacing-x-small);
+.u-nmb-2 {
+  margin-bottom: calc(var(--spacing-2) * -1);
 }
 
-.u-ml-xsm {
-  margin-left: var(--spacing-x-small);
+.u-nml-2 {
+  margin-left: calc(var(--spacing-2) * -1);
 }
 
-.u-mt-sm {
-  margin-top: var(--spacing-small);
+.u-nmt,
+.u-nmt-3 {
+  margin-top: calc(var(--spacing-3) * -1);
 }
 
-.u-mr-sm {
-  margin-right: var(--spacing-small);
+.u-nmr,
+.u-nmr-3 {
+  margin-right: calc(var(--spacing-3) * -1);
 }
 
-.u-mb-sm {
-  margin-bottom: var(--spacing-small);
+.u-nmb,
+.u-nmb-3 {
+  margin-bottom: calc(var(--spacing-3) * -1);
 }
 
-.u-ml-sm {
-  margin-left: var(--spacing-small);
+.u-nml,
+.u-nml-3 {
+  margin-left: calc(var(--spacing-3) * -1);
 }
 
-.u-mt,
-.u-mt-base {
-  margin-top: var(--spacing-normal);
+.u-nmt-4 {
+  margin-top: calc(var(--spacing-4) * -1);
 }
 
-.u-mr,
-.u-mr-base {
-  margin-right: var(--spacing-normal);
+.u-nmr-4 {
+  margin-right: calc(var(--spacing-4) * -1);
 }
 
-.u-mb,
-.u-mb-base {
-  margin-bottom: var(--spacing-normal);
+.u-nmb-4 {
+  margin-bottom: calc(var(--spacing-4) * -1);
 }
 
-.u-ml,
-.u-ml-base {
-  margin-left: var(--spacing-normal);
+.u-nml-4 {
+  margin-left: calc(var(--spacing-4) * -1);
 }
 
-.u-mt-md {
-  margin-top: var(--spacing-medium);
+.u-nmt-5 {
+  margin-top: calc(var(--spacing-5) * -1);
 }
 
-.u-mr-md {
-  margin-right: var(--spacing-medium);
+.u-nmr-5 {
+  margin-right: calc(var(--spacing-5) * -1);
 }
 
-.u-mb-md {
-  margin-bottom: var(--spacing-medium);
+.u-nmb-5 {
+  margin-bottom: calc(var(--spacing-5) * -1);
 }
 
-.u-ml-md {
-  margin-left: var(--spacing-medium);
+.u-nml-5 {
+  margin-left: calc(var(--spacing-5) * -1);
 }
 
-.u-mt-lg {
-  margin-top: var(--spacing-large);
+.u-nmt-6 {
+  margin-top: calc(var(--spacing-6) * -1);
 }
 
-.u-mr-lg {
-  margin-right: var(--spacing-large);
+.u-nmr-6 {
+  margin-right: calc(var(--spacing-6) * -1);
 }
 
-.u-mb-lg {
-  margin-bottom: var(--spacing-large);
+.u-nmb-6 {
+  margin-bottom: calc(var(--spacing-6) * -1);
 }
 
-.u-ml-lg {
-  margin-left: var(--spacing-large);
+.u-nml-6 {
+  margin-left: calc(var(--spacing-6) * -1);
 }
 
-.u-mt-xlg {
-  margin-top: var(--spacing-x-large);
+.u-nmt-7 {
+  margin-top: calc(var(--spacing-7) * -1);
 }
 
-.u-mr-xlg {
-  margin-right: var(--spacing-x-large);
+.u-nmr-7 {
+  margin-right: calc(var(--spacing-7) * -1);
 }
 
-.u-mb-xlg {
-  margin-bottom: var(--spacing-x-large);
+.u-nmb-7 {
+  margin-bottom: calc(var(--spacing-7) * -1);
 }
 
-.u-ml-xlg {
-  margin-left: var(--spacing-x-large);
+.u-nml-7 {
+  margin-left: calc(var(--spacing-7) * -1);
 }
 
-.u-mt-xxlg {
-  margin-top: var(--spacing-xx-large);
+.u-nmt-8 {
+  margin-top: calc(var(--spacing-8) * -1);
 }
 
-.u-mr-xxlg {
-  margin-right: var(--spacing-xx-large);
+.u-nmr-8 {
+  margin-right: calc(var(--spacing-8) * -1);
 }
 
-.u-mb-xxlg {
-  margin-bottom: var(--spacing-xx-large);
+.u-nmb-8 {
+  margin-bottom: calc(var(--spacing-8) * -1);
 }
 
-.u-ml-xxlg {
-  margin-left: var(--spacing-xx-large);
+.u-nml-8 {
+  margin-left: calc(var(--spacing-8) * -1);
 }
 
-.u-mt-xxxlg {
-  margin-top: var(--spacing-xxx-large);
+.u-nmt-9 {
+  margin-top: calc(var(--spacing-9) * -1);
 }
 
-.u-mr-xxxlg {
-  margin-right: var(--spacing-xxx-large);
+.u-nmr-9 {
+  margin-right: calc(var(--spacing-9) * -1);
 }
 
-.u-mb-xxxlg {
-  margin-bottom: var(--spacing-xxx-large);
+.u-nmb-9 {
+  margin-bottom: calc(var(--spacing-9) * -1);
 }
 
-.u-ml-xxxlg {
-  margin-left: var(--spacing-xxx-large);
+.u-nml-9 {
+  margin-left: calc(var(--spacing-9) * -1);
+}
+
+.u-nmt-10 {
+  margin-top: calc(var(--spacing-10) * -1);
+}
+
+.u-nmr-10 {
+  margin-right: calc(var(--spacing-10) * -1);
+}
+
+.u-nmb-10 {
+  margin-bottom: calc(var(--spacing-10) * -1);
+}
+
+.u-nml-10 {
+  margin-left: calc(var(--spacing-10) * -1);
+}
+
+.u-nmt-11 {
+  margin-top: calc(var(--spacing-11) * -1);
+}
+
+.u-nmr-11 {
+  margin-right: calc(var(--spacing-11) * -1);
+}
+
+.u-nmb-11 {
+  margin-bottom: calc(var(--spacing-11) * -1);
+}
+
+.u-nml-11 {
+  margin-left: calc(var(--spacing-11) * -1);
+}
+
+.u-nmt-12 {
+  margin-top: calc(var(--spacing-12) * -1);
+}
+
+.u-nmr-12 {
+  margin-right: calc(var(--spacing-12) * -1);
+}
+
+.u-nmb-12 {
+  margin-bottom: calc(var(--spacing-12) * -1);
+}
+
+.u-nml-12 {
+  margin-left: calc(var(--spacing-12) * -1);
+}
+
+.u-nmt-13 {
+  margin-top: calc(var(--spacing-13) * -1);
+}
+
+.u-nmr-13 {
+  margin-right: calc(var(--spacing-13) * -1);
+}
+
+.u-nmb-13 {
+  margin-bottom: calc(var(--spacing-13) * -1);
+}
+
+.u-nml-13 {
+  margin-left: calc(var(--spacing-13) * -1);
 }

--- a/src/utils/spacing/margin.css
+++ b/src/utils/spacing/margin.css
@@ -6,7 +6,6 @@
   margin: var(--spacing-2);
 }
 
-.u-m,
 .u-m-3 {
   margin: var(--spacing-3);
 }
@@ -19,6 +18,7 @@
   margin: var(--spacing-5);
 }
 
+.u-m,
 .u-m-6 {
   margin: var(--spacing-6);
 }
@@ -63,7 +63,6 @@
   margin: calc(var(--spacing-2) * -1);
 }
 
-.u-nm,
 .u-nm-3 {
   margin: calc(var(--spacing-3) * -1);
 }
@@ -76,6 +75,7 @@
   margin: calc(var(--spacing-5) * -1);
 }
 
+.u-nm,
 .u-nm-6 {
   margin: calc(var(--spacing-6) * -1);
 }
@@ -128,13 +128,11 @@
   margin-left: var(--spacing-2);
 }
 
-.u-my,
 .u-my-3 {
   margin-top: var(--spacing-3);
   margin-bottom: var(--spacing-3);
 }
 
-.u-mx,
 .u-mx-3 {
   margin-right: var(--spacing-3);
   margin-left: var(--spacing-3);
@@ -160,11 +158,13 @@
   margin-left: var(--spacing-5);
 }
 
+.u-my,
 .u-my-6 {
   margin-top: var(--spacing-6);
   margin-bottom: var(--spacing-6);
 }
 
+.u-mx,
 .u-mx-6 {
   margin-right: var(--spacing-6);
   margin-left: var(--spacing-6);
@@ -270,13 +270,11 @@
   margin-left: calc(var(--spacing-2) * -1);
 }
 
-.u-nmy,
 .u-nmy-3 {
   margin-top: calc(var(--spacing-3) * -1);
   margin-bottom: calc(var(--spacing-3) * -1);
 }
 
-.u-nmx,
 .u-nmx-3 {
   margin-right: calc(var(--spacing-3) * -1);
   margin-left: calc(var(--spacing-3) * -1);
@@ -302,11 +300,13 @@
   margin-left: calc(var(--spacing-5) * -1);
 }
 
+.u-nmy,
 .u-nmy-6 {
   margin-top: calc(var(--spacing-6) * -1);
   margin-bottom: calc(var(--spacing-6) * -1);
 }
 
+.u-nmx,
 .u-nmx-6 {
   margin-right: calc(var(--spacing-6) * -1);
   margin-left: calc(var(--spacing-6) * -1);
@@ -414,22 +414,18 @@
   margin-left: var(--spacing-2);
 }
 
-.u-mt,
 .u-mt-3 {
   margin-top: var(--spacing-3);
 }
 
-.u-mr,
 .u-mr-3 {
   margin-right: var(--spacing-3);
 }
 
-.u-mb,
 .u-mb-3 {
   margin-bottom: var(--spacing-3);
 }
 
-.u-ml,
 .u-ml-3 {
   margin-left: var(--spacing-3);
 }
@@ -466,18 +462,22 @@
   margin-left: var(--spacing-5);
 }
 
+.u-mt,
 .u-mt-6 {
   margin-top: var(--spacing-6);
 }
 
+.u-mr,
 .u-mr-6 {
   margin-right: var(--spacing-6);
 }
 
+.u-mb,
 .u-mb-6 {
   margin-bottom: var(--spacing-6);
 }
 
+.u-ml,
 .u-ml-6 {
   margin-left: var(--spacing-6);
 }
@@ -642,22 +642,18 @@
   margin-left: calc(var(--spacing-2) * -1);
 }
 
-.u-nmt,
 .u-nmt-3 {
   margin-top: calc(var(--spacing-3) * -1);
 }
 
-.u-nmr,
 .u-nmr-3 {
   margin-right: calc(var(--spacing-3) * -1);
 }
 
-.u-nmb,
 .u-nmb-3 {
   margin-bottom: calc(var(--spacing-3) * -1);
 }
 
-.u-nml,
 .u-nml-3 {
   margin-left: calc(var(--spacing-3) * -1);
 }
@@ -694,18 +690,22 @@
   margin-left: calc(var(--spacing-5) * -1);
 }
 
+.u-nmt,
 .u-nmt-6 {
   margin-top: calc(var(--spacing-6) * -1);
 }
 
+.u-nmr,
 .u-nmr-6 {
   margin-right: calc(var(--spacing-6) * -1);
 }
 
+.u-nmb,
 .u-nmb-6 {
   margin-bottom: calc(var(--spacing-6) * -1);
 }
 
+.u-nml,
 .u-nml-6 {
   margin-left: calc(var(--spacing-6) * -1);
 }

--- a/tokens/spacing.json
+++ b/tokens/spacing.json
@@ -20,48 +20,68 @@
       "comment": "Grid column size"
     },
     {
-      "name": "SPACING_XX_SMALL",
-      "value": "0.444rem",
+      "name": "SPACING_1",
+      "value": "0.25rem",
       "comment": "For micro adjustments"
     },
     {
-      "name": "SPACING_X_SMALL",
-      "value": "0.667rem",
+      "name": "SPACING_2",
+      "value": "0.5rem",
       "comment": "For micro adjustments"
     },
     {
-      "name": "SPACING_SMALL",
+      "name": "SPACING_3",
+      "value": "0.75rem",
+      "comment": "For paddings in labels / inline stuff"
+    },
+    {
+      "name": "SPACING_4",
       "value": "1rem",
       "comment": "For paddings in labels / inline stuff"
     },
     {
-      "name": "SPACING_NORMAL",
+      "name": "SPACING_5",
+      "value": "1.25rem",
+      "comment": "For paddings in labels / inline stuff"
+    },
+    {
+      "name": "SPACING_6",
       "value": "1.5rem",
       "comment": "Regular padding for compact tables and such."
     },
     {
-      "name": "SPACING_MEDIUM",
+      "name": "SPACING_8",
+      "value": "2rem",
+      "comment": "Regular padding for compact tables and such."
+    },
+    {
+      "name": "SPACING_9",
       "value": "2.25rem",
       "comment": "For paddings in labels / inline stuff"
     },
     {
-      "name": "SPACING_LARGE",
-      "value": "3.375rem",
+      "name": "SPACING_12",
+      "value": "3rem",
       "comment": "Padding for the inside of boxes"
     },
     {
-      "name": "SPACING_X_LARGE",
-      "value": "5.0625rem",
+      "name": "SPACING_16",
+      "value": "4rem",
+      "comment": "Padding for the inside of boxes"
+    },
+    {
+      "name": "SPACING_20",
+      "value": "5rem",
       "comment": "Padding between elements and for boxes with larger font-sizes"
     },
     {
-      "name": "SPACING_XX_LARGE",
-      "value": "7.6rem",
+      "name": "SPACING_32",
+      "value": "8rem",
       "comment": "Larger padding for when bigger spacing is needed"
     },
     {
-      "name": "SPACING_XXX_LARGE",
-      "value": "11.4rem",
+      "name": "SPACING_48",
+      "value": "12rem",
       "comment": "Huge padding we can use for seperation of vertical sections"
     },
     {

--- a/tokens/spacing.json
+++ b/tokens/spacing.json
@@ -21,68 +21,55 @@
     },
     {
       "name": "SPACING_1",
-      "value": "0.25rem",
-      "comment": "For micro adjustments"
+      "value": "0.25rem"
     },
     {
       "name": "SPACING_2",
-      "value": "0.5rem",
-      "comment": "For micro adjustments"
+      "value": "0.5rem"
     },
     {
       "name": "SPACING_3",
-      "value": "0.75rem",
-      "comment": "For paddings in labels / inline stuff"
+      "value": "0.75rem"
     },
     {
       "name": "SPACING_4",
-      "value": "1rem",
-      "comment": "For paddings in labels / inline stuff"
+      "value": "1rem"
     },
     {
       "name": "SPACING_5",
-      "value": "1.25rem",
-      "comment": "For paddings in labels / inline stuff"
+      "value": "1.25rem"
     },
     {
       "name": "SPACING_6",
-      "value": "1.5rem",
-      "comment": "Regular padding for compact tables and such."
+      "value": "1.5rem"
+    },
+    {
+      "name": "SPACING_7",
+      "value": "2rem"
     },
     {
       "name": "SPACING_8",
-      "value": "2rem",
-      "comment": "Regular padding for compact tables and such."
+      "value": "2.25rem"
     },
     {
       "name": "SPACING_9",
-      "value": "2.25rem",
-      "comment": "For paddings in labels / inline stuff"
+      "value": "3rem"
+    },
+    {
+      "name": "SPACING_10",
+      "value": "4rem"
+    },
+    {
+      "name": "SPACING_11",
+      "value": "5rem"
     },
     {
       "name": "SPACING_12",
-      "value": "3rem",
-      "comment": "Padding for the inside of boxes"
+      "value": "8rem"
     },
     {
-      "name": "SPACING_16",
-      "value": "4rem",
-      "comment": "Padding for the inside of boxes"
-    },
-    {
-      "name": "SPACING_20",
-      "value": "5rem",
-      "comment": "Padding between elements and for boxes with larger font-sizes"
-    },
-    {
-      "name": "SPACING_32",
-      "value": "8rem",
-      "comment": "Larger padding for when bigger spacing is needed"
-    },
-    {
-      "name": "SPACING_48",
-      "value": "12rem",
-      "comment": "Huge padding we can use for seperation of vertical sections"
+      "name": "SPACING_13",
+      "value": "12rem"
     },
     {
       "name": "BREAK_SMALL",


### PR DESCRIPTION
We currently use a spacing scale that generates half pixels, i.e. 0.667
* 16 => 10.672 pixels. To give a bit more flexibility (and spacings that
  we actually need in components) I converted this to a factor of 0.25.
  So that means spacing-3 will be 3*.25rem => 0.75 rem = 12px.

having this scale allows us to have a bit more gaps on the lower range
of the spacing scale, and bigger gaps on the top of the scale.