### PR TITLE
Remove border declarations from reset.css

### DIFF
--- a/utilities/_reset.sass
+++ b/utilities/_reset.sass
@@ -1,7 +1,6 @@
 html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video
   margin: 0
   padding: 0
-  border: 0
   font: inherit
   font-size: 100%
   vertical-align: baseline


### PR DESCRIPTION
This fixes the `border-style: none`, avoiding Tailwind to add a default border by just adding `.border` or `.border-b`