### PR TITLE
Remove metric icon

### DIFF
--- a/utilities/_variables.scss
+++ b/utilities/_variables.scss
@@ -83,7 +83,6 @@ $navigation: (
   ),
   (
     class: "metrics",
-    icon: "fa-area-chart",
     color: $red,
     background: linear-gradient(125deg,$red,darken($red,10))
   ),


### PR DESCRIPTION
The name of this icon is changing when in the update from FontAwesome 4 to 5. This is breaking the build of https://github.com/appsignal/appsignal-server/pull/5761.

I have no idea where the design language is being used besides the app. But in the app the whole `$navigation` is overwritten anyway, so I guess we can just remove the icon here (and hopefully the whole file soon).

Can we just remove it or is this breaking something else?