### PR TITLE
Fix .hidden class

### DIFF
--- a/utilities/_mixins.sass
+++ b/utilities/_mixins.sass
@@ -6,8 +6,7 @@
   text-align: center
 
 @mixin hide
-  left: -9999px
-  position: absolute
+  display: none
 
 @mixin hide-text
   text-indent: -100em


### PR DESCRIPTION
For some reason .hidden was defined as:
```css
left: -9999px;
position: absolute;
```

This doesn't really make sense and breaks the new design. It should be:
```css
display: none;
```

I haven't found any instance where the old implementation was necessary. But I guess there was a reason why this was implemented like this?