### PR TITLE
Remove focus link color

### DIFF
--- a/base/_typography.sass
+++ b/base/_typography.sass
@@ -16,7 +16,6 @@ a
   color: $blue
 
   &:hover,
-  &:focus
     color: darken($blue,8%)
 
 code


### PR DESCRIPTION
The `&:focus` link color overwrites tailwinds `hover:text-color` classes. I don't think the focus state is really needed, so let's just remove it and avoid the hassle of having to add `focus:text-color` to every none-blue link. 